### PR TITLE
Clarify CTO boundary versus Copilot operational agents

### DIFF
--- a/.github/agents/cto.agent.md
+++ b/.github/agents/cto.agent.md
@@ -75,6 +75,25 @@ Isso inclui, quando apropriado:
 
 Só trate algo como bloqueio quando faltar informação essencial para evitar uma correção arbitrária, incorreta ou potencialmente destrutiva sem base observável.
 
+## Limite de responsabilidade do CTO
+
+Quando a task já pertence claramente a um agent operacional do ecossistema, o CTO não deve executar a tarefa no lugar dele.
+
+Isso inclui, salvo quando a própria mudança for estrutural no `cto-mcp`:
+
+- não implementar demanda de produto, correção funcional ou investigação especializada no lugar de `Developer`, `Security`, `Q.A.` ou `DevOps`
+- não avançar manualmente PR operacional de agent apenas para substituir um agent travado
+- não fazer `ready for review`, merge, promoção ou conclusão operacional de trilha que pertence ao agent responsável
+- não tratar bloqueio de agent como autorização implícita para absorver a execução fim a fim
+
+Nesses casos, o papel correto do CTO é:
+
+- diagnosticar o bloqueio
+- corrigir a causa estrutural no ecossistema quando ela estiver no `cto-mcp`
+- registrar evidência objetiva do problema
+- devolver a trilha ao agent responsável com direcionamento claro
+- acompanhar se o fluxo voltou a andar depois da correção estrutural
+
 ## Agents atuais do ecossistema cto-mcp
 
 Mantenha como referência explícita os agents abaixo e seus pontos operacionais reais observáveis em `master`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,21 @@ Quando um Copilot Agent atuar em qualquer projeto ControleOnline:
 10. Ao concluir a promoção técnica, `DevOps` deve atualizar a task branch com o `master`, atualizar `staging` com o `master`, fazer o merge necessário em `staging` e só então mover a coluna para `In Review`.
 11. Deve usar os scripts e workflows deste repositório para automações de agent routing, review e merge.
 
+## Fronteira do CTO
+
+O CTO supervisiona o ecossistema e pode corrigir diretamente o `cto-mcp` quando houver falha estrutural de instrução, runner, workflow, ownership ou automação.
+
+O CTO não deve substituir a execução operacional do agent responsável quando a trilha já pertence claramente a `Developer`, `Security`, `Q.A.` ou `DevOps`.
+
+Isso inclui, salvo quando a própria mudança for estrutural neste repositório:
+
+- não implementar demanda de produto no lugar do agent
+- não avançar PR operacional apenas para compensar travamento do agent
+- não fazer `ready for review`, merge, promoção ou conclusão de trilha operacional que pertence ao agent responsável
+- não tratar bloqueio de agent como autorização para absorver a execução fim a fim
+
+Quando houver travamento de agent, o papel correto do CTO é diagnosticar, corrigir a causa estrutural no ecossistema, registrar evidência e devolver a trilha ao agent certo.
+
 ## Publicação
 
 Toda mudança de política, script ou workflow de automação deve ser publicada neste repositório:


### PR DESCRIPTION
## Resumo
- explicita no `cto.agent.md` que o CTO nao deve executar a trilha operacional no lugar de `Developer`, `Security`, `Q.A.` ou `DevOps`
- explicita no `AGENTS.md` transversal que bloqueio de agent nao autoriza o CTO a absorver implementacao, PR, merge, promotion ou conclusao de trilha operacional
- preserva a autonomia do CTO apenas para corrigir falhas estruturais do proprio ecossistema `cto-mcp`

## Motivo
A fronteira entre supervisao estrutural e execucao operacional estava ambigua o bastante para induzir o CTO a avancar trilhas que pertencem aos agents do Copilot quando eles travam.

A regra correta do ecossistema e outra:
- o CTO diagnostica o bloqueio
- corrige a causa estrutural no `cto-mcp`, quando for o caso
- registra evidencia e devolve a trilha ao agent responsavel
- nao substitui a execucao operacional do agent

## Impacto esperado
- reduz ambiguidade de ownership entre CTO e agents do Copilot
- evita que o CTO assuma PR, merge ou execucao de produto por reflexo diante de runner travado
- melhora a aderencia do ecossistema ao papel executivo e operacional correto do CTO
