### PR TITLE
Replace assignee-based agent routing with tags-only workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,9 @@ Regras obrigatorias:
 - nenhuma task deve ser atribuida a pessoas, bots ou fallbacks tecnicos como mecanismo de captura de trabalho
 - assignees do GitHub nao participam do roteamento operacional e devem ser removidos quando aparecerem em tasks da fila
 - todos os agents devem descobrir trabalho lendo tags e coluna da issue, nunca assignees
-- task aberta em `Work` ou `Working` sem `agent:*` entra por `agent:developer`
+- agentes nao fecham tasks; so humanos podem mover uma issue para `closed`
+- para os agents, conclusao operacional significa avancar a task para a proxima coluna ou trocar a tag da proxima etapa, sem usar `open` ou `closed` como gate de trabalho
+- task em `Work` ou `Working` sem `agent:*` entra por `agent:developer`
 - `Developer`, `Security`, `Quality Assurance` e `Sysadmin` trabalham a partir da coluna `Work` ou `Working`
 - `DevOps` verifica suas tasks na coluna `Deploy`
 - agents documentais fora do nucleo, como `Documentor`, verificam suas tasks na coluna `Done`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,12 +63,16 @@ Labels validos:
 
 Regras obrigatorias:
 
-- o label `agent:*` define o agent responsavel atual
-- task aberta em `Work` sem `agent:*` entra por `Developer`
-- o assignee `Copilot` indica apenas execucao ativa
-- o agent atual troca o label ao concluir a propria etapa
-- `DevOps` e o unico que move a task para `In Review`
-- `Sysadmin` pode manter ou criar acompanhamento operacional em `Work` e abrir etapa de validacao em `In Review` quando houver necessidade operacional posterior
+- nenhuma task deve ser atribuida a pessoas, bots ou fallbacks tecnicos como mecanismo de captura de trabalho
+- assignees do GitHub nao participam do roteamento operacional e devem ser removidos quando aparecerem em tasks da fila
+- todos os agents devem descobrir trabalho lendo tags e coluna da issue, nunca assignees
+- task aberta em `Work` ou `Working` sem `agent:*` entra por `agent:developer`
+- `Developer`, `Security`, `Quality Assurance` e `Sysadmin` trabalham a partir da coluna `Work` ou `Working`
+- `DevOps` verifica suas tasks na coluna `Deploy`
+- agents documentais fora do nucleo, como `Documentor`, verificam suas tasks na coluna `Done`
+- qualquer agent que encontrar bloqueio de infraestrutura deve abrir ou atualizar uma issue separada em `Work` com tag `agent:sysadmin`, referenciando a issue bloqueada
+- a troca de tags continua definindo a etapa atual do fluxo tecnico
+- depois que a trilha tiver passado por `Developer`, `Security` e `Quality Assurance`, qualquer agent com evidencia concreta pode mover a task para `In Review`
 
 ## Fronteira do CTO
 

--- a/automate/scripts/agent-flow-sync.mjs
+++ b/automate/scripts/agent-flow-sync.mjs
@@ -13,38 +13,31 @@ const REST_API_URL = 'https://api.github.com';
 
 const AGENT_LABELS = {
   developer: 'agent:developer',
+  security: 'agent:security',
+  qa: 'agent:qa',
   devops: 'agent:devops',
+  sysadmin: 'agent:sysadmin',
 };
 
-const ALL_AGENT_LABELS = ['agent:developer', 'agent:security', 'agent:qa', 'agent:devops'];
-const DEFAULT_KNOWN_AGENT_LOGINS = 'github-copilot[bot],copilot-swe-agent,copilot';
-const DEFAULT_UNSUPPORTED_LABEL = 'ops:copilot-unavailable';
+const ALL_AGENT_LABELS = Object.values(AGENT_LABELS);
 const RETRY = githubRetryConfig('FLOW');
 const LABEL_META = {
-  'agent:developer': { color: '1f6feb', description: 'Task atualmente com o agent Developer' },
-  'agent:security': { color: 'd1242f', description: 'Task atualmente com o agent Security' },
-  'agent:qa': { color: '8b5cf6', description: 'Task atualmente com o agent QA' },
-  'agent:devops': { color: 'fb8c00', description: 'Task atualmente com o agent DevOps' },
-  'ops:copilot-unavailable': {
-    color: 'd4a72c',
-    description: 'Copilot cloud agent nao habilitado no repositorio alvo',
-  },
+  'agent:developer': { color: '1f6feb', description: 'Task marcada para a etapa de Developer' },
+  'agent:security': { color: 'd1242f', description: 'Task marcada para a etapa de Security' },
+  'agent:qa': { color: '8b5cf6', description: 'Task marcada para a etapa de QA' },
+  'agent:devops': { color: 'fb8c00', description: 'Task marcada para a etapa de DevOps' },
+  'agent:sysadmin': { color: '0e8a16', description: 'Task marcada para acompanhamento do Sysadmin' },
 };
 const COMMENT_MARKER_PREFIX = 'cto-mcp-flow-sync';
 const COMMENT_TYPES = {
   seedDeveloper: 'seed-developer',
-  clearOrphanAgentAssignee: 'clear-orphan-agent-assignee',
   routeConflictToDevops: 'route-conflict-to-devops',
-  releaseDevops: 'release-devops',
-  cleanupInReview: 'cleanup-in-review',
+  cleanupAssignees: 'cleanup-assignees',
+  cleanupReview: 'cleanup-review',
 };
 
 function env(name, fallback = '') {
   return (process.env[name] || fallback).trim();
-}
-
-function getToken() {
-  return env('GITHUB_TOKEN') || env('GH_TOKEN');
 }
 
 function parseCsv(value) {
@@ -52,6 +45,10 @@ function parseCsv(value) {
     .split(',')
     .map((item) => item.trim())
     .filter(Boolean);
+}
+
+function getToken() {
+  return env('GITHUB_TOKEN') || env('GH_TOKEN');
 }
 
 async function githubGraphQL(query, variables = {}) {
@@ -185,10 +182,6 @@ async function getProjectSnapshot(org, projectNumber) {
                 comments(last:10) {
                   nodes {
                     body
-                    createdAt
-                    author {
-                      login
-                    }
                   }
                 }
                 labels(first:20) {
@@ -198,7 +191,6 @@ async function getProjectSnapshot(org, projectNumber) {
                 }
                 assignees(first:20) {
                   nodes {
-                    id
                     login
                   }
                 }
@@ -270,29 +262,8 @@ function currentAgentLabel(issue) {
 
 function assigneeLogins(issue) {
   return (issue.assignees?.nodes || [])
-    .map((assignee) => (assignee?.login || '').trim().toLowerCase())
+    .map((assignee) => (assignee?.login || '').trim())
     .filter(Boolean);
-}
-
-function retainedHumanActorIds(issue, knownAgentLogins) {
-  return (issue.assignees?.nodes || [])
-    .filter((assignee) => {
-      const login = (assignee?.login || '').trim().toLowerCase();
-      return login && !knownAgentLogins.has(login) && assignee?.id;
-    })
-    .map((assignee) => assignee.id);
-}
-
-function hasAgentAssignee(issue, knownAgentLogins) {
-  return assigneeLogins(issue).some((login) => knownAgentLogins.has(login));
-}
-
-function hasHumanAssignee(issue, knownAgentLogins) {
-  return assigneeLogins(issue).some((login) => !knownAgentLogins.has(login));
-}
-
-function hasHumanOnlyAssignee(issue, knownAgentLogins) {
-  return hasHumanAssignee(issue, knownAgentLogins) && !hasAgentAssignee(issue, knownAgentLogins);
 }
 
 function normalizePullRequests(issue) {
@@ -311,10 +282,6 @@ function normalizePullRequests(issue) {
 
 function openPullRequests(issue) {
   return normalizePullRequests(issue).filter((pr) => pr?.state === 'OPEN');
-}
-
-function hasOpenPullRequest(issue) {
-  return openPullRequests(issue).length > 0;
 }
 
 function openPullRequestsInSameRepository(issue) {
@@ -347,6 +314,11 @@ function hasRecentCommentMarker(issue, type, signature) {
   return recentComments(issue).some((comment) => (comment?.body || '').includes(marker));
 }
 
+function statusMatches(status, allowedStatuses) {
+  const normalized = (status || '').trim().toLowerCase();
+  return allowedStatuses.some((entry) => entry.toLowerCase() === normalized);
+}
+
 async function ensureLabelExists(repoFullName, labelName) {
   const [owner, repo] = repoFullName.split('/');
   const meta = LABEL_META[labelName] || { color: '1f6feb', description: labelName };
@@ -373,22 +345,13 @@ async function replaceIssueLabels(repoFullName, issueNumber, nextLabels) {
   });
 }
 
-async function replaceAssignableActors(issueId, actorIds) {
-  return githubGraphQL(
-    `mutation($issueId:ID!, $actorIds:[ID!]!) {
-      replaceActorsForAssignable(input: {
-        assignableId: $issueId,
-        actorIds: $actorIds
-      }) {
-        assignable {
-          ... on Issue {
-            id
-          }
-        }
-      }
-    }`,
-    { issueId, actorIds }
-  );
+async function removeIssueAssignees(repoFullName, issueNumber, assignees) {
+  if (!assignees.length) return;
+  const [owner, repo] = repoFullName.split('/');
+  await githubRest(`/repos/${owner}/${repo}/issues/${issueNumber}/assignees`, {
+    method: 'DELETE',
+    body: JSON.stringify({ assignees }),
+  });
 }
 
 async function addIssueComment(issueId, body) {
@@ -408,26 +371,13 @@ async function addIssueComment(issueId, body) {
 
 function buildDeveloperSeedComment(issueRef, signature) {
   return [
-    '### Fluxo iniciado automaticamente',
+    '### Fluxo iniciado por tags',
     '',
     `Issue: ${issueRef}`,
-    'Ação: a task entrou sem `agent:*` em `Work`, então o fluxo oficial apontou a responsabilidade inicial para `agent:developer`.',
-    'Próximo passo: o runner de `Developer` fará a captura quando não houver outra execução ativa do mesmo agent.',
+    'Ação: a task entrou em `Work` ou `Working` sem `agent:*`, então a trilha oficial marcou `agent:developer` como primeira etapa.',
+    'Próximo passo: o agent `Developer` deve descobrir essa task pela tag e pela coluna, sem uso de assignee.',
     '',
     buildCommentMarker(COMMENT_TYPES.seedDeveloper, signature),
-  ].join('\n');
-}
-
-function buildOrphanAgentCleanupComment(issueRef, signature) {
-  return [
-    '### Higienização de ownership técnico',
-    '',
-    `Issue: ${issueRef}`,
-    'Motivo: a task estava em `Work` com assignee técnico do Copilot, mas sem `agent:*` ativo que justificasse execução em andamento.',
-    'Ação: o assignee técnico foi removido para restaurar o estado neutro da fila e evitar que a task fosse tratada como execução ativa sem owner operacional claro.',
-    'Próximo passo: o sincronizador pode semear novamente `agent:developer` na próxima rodada, permitindo captura limpa pelo runner correto.',
-    '',
-    buildCommentMarker(COMMENT_TYPES.clearOrphanAgentAssignee, signature),
   ].join('\n');
 }
 
@@ -437,38 +387,35 @@ function buildConflictComment(issueRef, signature) {
     '',
     `Issue: ${issueRef}`,
     'Motivo: foi detectado PR aberto com conflito no mesmo repositório da issue/composição.',
-    'Ação: a responsabilidade atual foi movida para `agent:devops` para que o conflito seja resolvido antes do fluxo continuar.',
+    'Ação: a responsabilidade atual foi marcada com `agent:devops`; a captura deve acontecer pela tag e pela coluna `Deploy`, sem assignee.',
     '',
     buildCommentMarker(COMMENT_TYPES.routeConflictToDevops, signature),
   ].join('\n');
 }
 
-function buildDevopsReleaseComment(issueRef, returnedToDeveloper, signature) {
+function buildAssigneeCleanupComment(issueRef, signature) {
   return [
-    '### Fluxo devolvido de DevOps',
+    '### Limpeza de atribuicoes',
     '',
     `Issue: ${issueRef}`,
-    'Motivo: não existe mais PR aberto com conflito no mesmo repositório da issue/composição.',
-    returnedToDeveloper
-      ? 'Ação: a responsabilidade foi devolvida para `agent:developer`, porque o próximo passo volta a ser republicar a trilha técnica ou a composição correta.'
-      : 'Ação: o label `agent:devops` foi removido para evitar ownership operacional incorreto enquanto houver apenas assignee humano ativo.',
+    'Ação: os assignees foram removidos porque a captura de trabalho agora acontece apenas por tags e coluna.',
     '',
-    buildCommentMarker(COMMENT_TYPES.releaseDevops, signature),
+    buildCommentMarker(COMMENT_TYPES.cleanupAssignees, signature),
   ].join('\n');
 }
 
-function buildInReviewCleanupComment(issueRef, signature) {
+function buildReviewCleanupComment(issueRef, signature) {
   return [
     '### Limpeza final de fluxo',
     '',
     `Issue: ${issueRef}`,
-    'Ação: a task já está em `In Review`, então os labels `agent:*` e o assignee técnico do Copilot foram removidos para deixar o estado final coerente.',
+    'Ação: a task entrou em `In Review`, então as tags `agent:*` residuais foram removidas para deixar o estado final coerente.',
     '',
-    buildCommentMarker(COMMENT_TYPES.cleanupInReview, signature),
+    buildCommentMarker(COMMENT_TYPES.cleanupReview, signature),
   ].join('\n');
 }
 
-function serializeItem(item, knownAgentLogins) {
+function serializeItem(item) {
   const issue = item.content;
   const pullRequests = normalizePullRequests(issue);
   return {
@@ -486,9 +433,6 @@ function serializeItem(item, knownAgentLogins) {
     labels: issueLabels(issue),
     currentAgentLabel: currentAgentLabel(issue),
     assignees: assigneeLogins(issue),
-    hasAgentAssignee: hasAgentAssignee(issue, knownAgentLogins),
-    hasHumanAssignee: hasHumanAssignee(issue, knownAgentLogins),
-    hasHumanOnlyAssignee: hasHumanOnlyAssignee(issue, knownAgentLogins),
     openPullRequests: pullRequests
       .filter((pr) => pr?.state === 'OPEN')
       .map((pr) => ({
@@ -496,18 +440,6 @@ function serializeItem(item, knownAgentLogins) {
         url: pr.url,
         mergeable: pr.mergeable,
       })),
-    conflictingPullRequests: pullRequests
-      .filter((pr) => pr?.state === 'OPEN' && isConflictingOrBlockedMergeable(pr?.mergeable))
-      .map((pr) => ({
-        ref: `${pr.repository.nameWithOwner}#${pr.number}`,
-        url: pr.url,
-        mergeable: pr.mergeable,
-      })),
-    sameRepositoryOpenPullRequests: openPullRequestsInSameRepository(issue).map((pr) => ({
-      ref: `${pr.repository.nameWithOwner}#${pr.number}`,
-      url: pr.url,
-      mergeable: pr.mergeable,
-    })),
   };
 }
 
@@ -523,12 +455,10 @@ async function main() {
   const org = env('FLOW_PROJECT_ORG', 'ControleOnline');
   const projectNumber = Number(env('FLOW_PROJECT_NUMBER', '1'));
   const dryRun = env('FLOW_DRY_RUN', 'true').toLowerCase() !== 'false';
-  const workStatus = env('FLOW_WORK_STATUS', 'Work');
-  const inReviewStatus = env('FLOW_IN_REVIEW_STATUS', 'In Review');
-  const unsupportedLabel = env('FLOW_UNSUPPORTED_LABEL', DEFAULT_UNSUPPORTED_LABEL);
-  const knownAgentLogins = new Set(
-    parseCsv(env('FLOW_KNOWN_AGENT_LOGINS', DEFAULT_KNOWN_AGENT_LOGINS)).map((login) => login.toLowerCase())
-  );
+  const workStatuses = parseCsv(env('FLOW_WORK_STATUSES', 'Work,Working'));
+  const deployStatuses = parseCsv(env('FLOW_DEPLOY_STATUSES', 'Deploy'));
+  const inReviewStatuses = parseCsv(env('FLOW_IN_REVIEW_STATUSES', 'In Review'));
+  const doneStatuses = parseCsv(env('FLOW_DONE_STATUSES', 'Done'));
 
   const data = await getProjectSnapshot(org, projectNumber);
   const project = data?.organization?.projectV2;
@@ -544,8 +474,10 @@ async function main() {
       id: project.id,
       title: project.title,
     },
-    workStatus,
-    inReviewStatus,
+    workStatuses,
+    deployStatuses,
+    inReviewStatuses,
+    doneStatuses,
     actions: [],
   };
 
@@ -557,145 +489,37 @@ async function main() {
     const issueRef = `${issue.repository.nameWithOwner}#${issue.number}`;
     const status = getStatusValue(item);
     const labels = issueLabels(issue);
-    const blockedByUnsupportedCopilot = labels.includes(unsupportedLabel);
     const stageLabel = currentAgentLabel(issue);
-    const agentAssigned = hasAgentAssignee(issue, knownAgentLogins);
-    const humanOnlyAssigned = hasHumanOnlyAssignee(issue, knownAgentLogins);
-    const record = serializeItem(item, knownAgentLogins);
+    const assignees = assigneeLogins(issue);
+    const record = serializeItem(item);
+
+    if (assignees.length > 0 && (statusMatches(status, workStatuses) || statusMatches(status, deployStatuses))) {
+      const signature = commentSignature({
+        type: COMMENT_TYPES.cleanupAssignees,
+        issueRef,
+        assignees: [...assignees].sort(),
+        status,
+      });
+      const duplicateComment = hasRecentCommentMarker(issue, COMMENT_TYPES.cleanupAssignees, signature);
+      const action = {
+        type: 'cleanup-assignees',
+        issue: record.issue,
+        assignees,
+        skippedDuplicateComment: duplicateComment,
+      };
+      result.actions.push(action);
+      if (!dryRun) {
+        await removeIssueAssignees(issue.repository.nameWithOwner, issue.number, assignees);
+        if (!duplicateComment) {
+          await addIssueComment(issue.id, buildAssigneeCleanupComment(issueRef, signature));
+        }
+      }
+    }
 
     if (
-      !blockedByUnsupportedCopilot &&
-      status?.toLowerCase() === workStatus.toLowerCase() &&
-      stageLabel === AGENT_LABELS.devops &&
+      statusMatches(status, workStatuses) &&
+      !stageLabel &&
       !hasConflictingPullRequestInSameRepository(issue)
-    ) {
-      const returnedToDeveloper = !humanOnlyAssigned;
-      const nextLabels = returnedToDeveloper
-        ? [...new Set([...labels.filter((label) => !ALL_AGENT_LABELS.includes(label)), AGENT_LABELS.developer])]
-        : labels.filter((label) => !ALL_AGENT_LABELS.includes(label));
-      const preservedHumanActorIds = retainedHumanActorIds(issue, knownAgentLogins);
-      const signature = commentSignature({
-        type: COMMENT_TYPES.releaseDevops,
-        issueRef,
-        returnedToDeveloper,
-        nextLabels: [...nextLabels].sort(),
-        sameRepositoryOpenPullRequests: record.sameRepositoryOpenPullRequests,
-      });
-      const duplicateComment = hasRecentCommentMarker(issue, COMMENT_TYPES.releaseDevops, signature);
-      const action = {
-        type: 'release-devops-without-local-conflict',
-        issue: record.issue,
-        previewLabels: nextLabels,
-        returnedToDeveloper,
-        clearedAgentAssignee: agentAssigned,
-        preservedHumanActorCount: preservedHumanActorIds.length,
-        skippedDuplicateComment: duplicateComment,
-      };
-      result.actions.push(action);
-      if (!dryRun) {
-        if (returnedToDeveloper) {
-          await ensureLabelExists(issue.repository.nameWithOwner, AGENT_LABELS.developer);
-        }
-        await replaceIssueLabels(issue.repository.nameWithOwner, issue.number, nextLabels);
-        if (agentAssigned) {
-          await replaceAssignableActors(issue.id, preservedHumanActorIds);
-        }
-        if (!duplicateComment) {
-          await addIssueComment(issue.id, buildDevopsReleaseComment(issueRef, returnedToDeveloper, signature));
-        }
-      }
-      continue;
-    }
-
-    if (
-      !blockedByUnsupportedCopilot &&
-      stageLabel === AGENT_LABELS.qa &&
-      hasConflictingPullRequestInSameRepository(issue)
-    ) {
-      const nextLabels = [...new Set([...labels.filter((label) => !ALL_AGENT_LABELS.includes(label)), AGENT_LABELS.devops])];
-      const preservedHumanActorIds = retainedHumanActorIds(issue, knownAgentLogins);
-      const signature = commentSignature({
-        type: COMMENT_TYPES.routeConflictToDevops,
-        issueRef,
-        nextLabels: [...nextLabels].sort(),
-        conflictingPullRequests: record.conflictingPullRequests,
-      });
-      const duplicateComment = hasRecentCommentMarker(issue, COMMENT_TYPES.routeConflictToDevops, signature);
-      const action = {
-        type: 'route-conflict-to-devops',
-        issue: record.issue,
-        previewLabels: nextLabels,
-        clearedAgentAssignee: agentAssigned,
-        preservedHumanActorCount: preservedHumanActorIds.length,
-        skippedDuplicateComment: duplicateComment,
-      };
-      result.actions.push(action);
-      if (!dryRun) {
-        await ensureLabelExists(issue.repository.nameWithOwner, AGENT_LABELS.devops);
-        await replaceIssueLabels(issue.repository.nameWithOwner, issue.number, nextLabels);
-        if (agentAssigned) {
-          await replaceAssignableActors(issue.id, preservedHumanActorIds);
-        }
-        if (!duplicateComment) {
-          await addIssueComment(issue.id, buildConflictComment(issueRef, signature));
-        }
-      }
-      continue;
-    }
-
-    if (
-      !blockedByUnsupportedCopilot &&
-      status?.toLowerCase() === workStatus.toLowerCase() &&
-      !stageLabel &&
-      agentAssigned
-    ) {
-      const preservedHumanActorIds = retainedHumanActorIds(issue, knownAgentLogins);
-      const signature = commentSignature({
-        type: COMMENT_TYPES.clearOrphanAgentAssignee,
-        issueRef,
-        assignees: record.assignees,
-        preservedHumanActorIds,
-      });
-      const duplicateComment = hasRecentCommentMarker(issue, COMMENT_TYPES.clearOrphanAgentAssignee, signature);
-      const action = {
-        type: 'clear-orphan-agent-assignee',
-        issue: record.issue,
-        clearedAgentAssignee: true,
-        preservedHumanActorCount: preservedHumanActorIds.length,
-        skippedDuplicateComment: duplicateComment,
-      };
-      result.actions.push(action);
-      if (!dryRun) {
-        await replaceAssignableActors(issue.id, preservedHumanActorIds);
-        if (!duplicateComment) {
-          await addIssueComment(issue.id, buildOrphanAgentCleanupComment(issueRef, signature));
-        }
-      }
-      continue;
-    }
-
-    if (
-      !blockedByUnsupportedCopilot &&
-      status?.toLowerCase() === workStatus.toLowerCase() &&
-      !stageLabel &&
-      !humanOnlyAssigned &&
-      !agentAssigned &&
-      hasOpenPullRequest(issue)
-    ) {
-      result.actions.push({
-        type: 'hold-work-item-with-open-pr',
-        issue: record.issue,
-        openPullRequests: record.openPullRequests,
-      });
-      continue;
-    }
-
-    if (
-      !blockedByUnsupportedCopilot &&
-      status?.toLowerCase() === workStatus.toLowerCase() &&
-      !stageLabel &&
-      !humanOnlyAssigned &&
-      !agentAssigned
     ) {
       const nextLabels = [...new Set([...labels, AGENT_LABELS.developer])];
       const signature = commentSignature({
@@ -722,32 +546,55 @@ async function main() {
       continue;
     }
 
-    if (status?.toLowerCase() === inReviewStatus.toLowerCase() && (stageLabel || agentAssigned)) {
-      const nextLabels = labels.filter((label) => !ALL_AGENT_LABELS.includes(label));
-      const preservedHumanActorIds = retainedHumanActorIds(issue, knownAgentLogins);
+    if (
+      statusMatches(status, workStatuses) &&
+      hasConflictingPullRequestInSameRepository(issue) &&
+      stageLabel !== AGENT_LABELS.devops
+    ) {
+      const nextLabels = [...new Set([...labels.filter((label) => !ALL_AGENT_LABELS.includes(label)), AGENT_LABELS.devops])];
       const signature = commentSignature({
-        type: COMMENT_TYPES.cleanupInReview,
+        type: COMMENT_TYPES.routeConflictToDevops,
         issueRef,
-        nextLabels,
-        clearedAgentAssignee: agentAssigned,
+        nextLabels: [...nextLabels].sort(),
       });
-      const duplicateComment = hasRecentCommentMarker(issue, COMMENT_TYPES.cleanupInReview, signature);
+      const duplicateComment = hasRecentCommentMarker(issue, COMMENT_TYPES.routeConflictToDevops, signature);
       const action = {
-        type: 'cleanup-in-review',
+        type: 'route-conflict-to-devops',
         issue: record.issue,
         previewLabels: nextLabels,
-        clearedAgentAssignee: agentAssigned,
-        preservedHumanActorCount: preservedHumanActorIds.length,
+        skippedDuplicateComment: duplicateComment,
+      };
+      result.actions.push(action);
+      if (!dryRun) {
+        await ensureLabelExists(issue.repository.nameWithOwner, AGENT_LABELS.devops);
+        await replaceIssueLabels(issue.repository.nameWithOwner, issue.number, nextLabels);
+        if (!duplicateComment) {
+          await addIssueComment(issue.id, buildConflictComment(issueRef, signature));
+        }
+      }
+      continue;
+    }
+
+    if ((statusMatches(status, inReviewStatuses) || statusMatches(status, doneStatuses)) && stageLabel) {
+      const nextLabels = labels.filter((label) => !ALL_AGENT_LABELS.includes(label));
+      const signature = commentSignature({
+        type: COMMENT_TYPES.cleanupReview,
+        issueRef,
+        nextLabels: [...nextLabels].sort(),
+        status,
+      });
+      const duplicateComment = hasRecentCommentMarker(issue, COMMENT_TYPES.cleanupReview, signature);
+      const action = {
+        type: 'cleanup-stage-labels',
+        issue: record.issue,
+        previewLabels: nextLabels,
         skippedDuplicateComment: duplicateComment,
       };
       result.actions.push(action);
       if (!dryRun) {
         await replaceIssueLabels(issue.repository.nameWithOwner, issue.number, nextLabels);
-        if (agentAssigned) {
-          await replaceAssignableActors(issue.id, preservedHumanActorIds);
-        }
         if (!duplicateComment) {
-          await addIssueComment(issue.id, buildInReviewCleanupComment(issueRef, signature));
+          await addIssueComment(issue.id, buildReviewCleanupComment(issueRef, signature));
         }
       }
     }

--- a/automate/scripts/agent-flow-sync.mjs
+++ b/automate/scripts/agent-flow-sync.mjs
@@ -484,7 +484,6 @@ async function main() {
   for (const item of items) {
     const issue = item.content;
     if (!issue?.repository?.nameWithOwner) continue;
-    if (issue.state !== 'OPEN') continue;
 
     const issueRef = `${issue.repository.nameWithOwner}#${issue.number}`;
     const status = getStatusValue(item);

--- a/automate/scripts/agent-project-dispatch.mjs
+++ b/automate/scripts/agent-project-dispatch.mjs
@@ -208,7 +208,6 @@ function statusMatches(status, allowedStatuses) {
 function isEligibleForRole(item, role, workStatuses, deployStatuses) {
   const issue = item.content;
   if (!issue?.repository?.nameWithOwner) return false;
-  if (issue.state !== 'OPEN') return false;
 
   const stageLabel = currentAgentLabel(issue);
   const status = getStatusValue(item);
@@ -296,7 +295,7 @@ async function main() {
 
   result.ok = true;
   result.discoveryMode = 'labels-and-columns-only';
-  result.reason = 'Selecao concluida sem uso de assignee, fallback tecnico ou comentario automatico.';
+  result.reason = 'Selecao concluida sem uso de assignee, fallback tecnico, comentario automatico ou gate por open/closed.';
   const outPath = writeOutputFile(result);
   console.log(
     JSON.stringify(

--- a/automate/scripts/agent-project-dispatch.mjs
+++ b/automate/scripts/agent-project-dispatch.mjs
@@ -8,59 +8,35 @@ import {
 } from '../../src/retry.js';
 
 const GITHUB_API_URL = 'https://api.github.com/graphql';
-const REST_API_URL = 'https://api.github.com';
 
 const ROLE_META = {
   developer: {
     displayName: 'Developer',
     label: 'agent:developer',
-    selection: 'work',
-    commentHeader: 'Developer iniciado',
-    nextInstruction:
-      'Ao concluir, deixe comentário final objetivo, troque o label para `agent:security`, remova o assignee `Copilot` e preserve assignees humanos existentes.',
   },
   security: {
     displayName: 'Security',
     label: 'agent:security',
-    selection: 'label',
-    commentHeader: 'Security iniciado',
-    nextInstruction:
-      'Ao concluir, deixe comentário final objetivo, troque o label para `agent:qa` ou `agent:developer`, remova o assignee `Copilot` e preserve assignees humanos existentes.',
   },
   qa: {
     displayName: 'Quality Assurance',
     label: 'agent:qa',
-    selection: 'label',
-    commentHeader: 'Quality Assurance iniciado',
-    nextInstruction:
-      'Ao concluir, deixe comentário final objetivo, troque o label para `agent:devops`, `agent:security` ou `agent:developer`, remova o assignee `Copilot` e preserve assignees humanos existentes.',
   },
   devops: {
     displayName: 'DevOps',
     label: 'agent:devops',
-    selection: 'label',
-    commentHeader: 'DevOps iniciado',
-    nextInstruction:
-      'Ao concluir, deixe comentário final objetivo, mova a task para `In Review`, remova labels `agent:*`, remova o assignee `Copilot` e preserve assignees humanos existentes.',
   },
 };
 
-const ALL_AGENT_LABELS = Object.values(ROLE_META).map((entry) => entry.label);
-const DEFAULT_AGENT_LOGIN = 'github-copilot[bot]';
-const DEFAULT_KNOWN_AGENT_LOGINS = 'github-copilot[bot],copilot-swe-agent,copilot';
-const DEFAULT_STALE_AFTER_MINUTES = '30';
-const DEFAULT_UNSUPPORTED_LABEL = 'ops:copilot-unavailable';
+const ALL_AGENT_LABELS = [
+  'agent:developer',
+  'agent:security',
+  'agent:qa',
+  'agent:devops',
+  'agent:sysadmin',
+];
+
 const RETRY = githubRetryConfig('AGENT');
-const LABEL_META = {
-  'agent:developer': { color: '1f6feb', description: 'Task atualmente com o agent Developer' },
-  'agent:security': { color: 'd1242f', description: 'Task atualmente com o agent Security' },
-  'agent:qa': { color: '8b5cf6', description: 'Task atualmente com o agent QA' },
-  'agent:devops': { color: 'fb8c00', description: 'Task atualmente com o agent DevOps' },
-  'ops:copilot-unavailable': {
-    color: 'd4a72c',
-    description: 'Copilot cloud agent nao habilitado no repositorio alvo',
-  },
-};
 
 function env(name, fallback = '') {
   return (process.env[name] || fallback).trim();
@@ -71,11 +47,6 @@ function parseCsv(value) {
     .split(',')
     .map((item) => item.trim())
     .filter(Boolean);
-}
-
-function parsePositiveNumber(value, fallback) {
-  const number = Number(value);
-  return Number.isFinite(number) && number > 0 ? number : fallback;
 }
 
 function getRole() {
@@ -90,12 +61,7 @@ function getToken() {
   return env('GITHUB_TOKEN') || env('GH_TOKEN');
 }
 
-function isCopilotUnavailableError(error) {
-  const message = error?.message || String(error || '');
-  return message.includes('Copilot agent is not enabled in this repository');
-}
-
-async function githubGraphQL(query, variables = {}, extraHeaders = {}) {
+async function githubGraphQL(query, variables = {}) {
   const token = getToken();
   if (!token) throw new Error('Missing GitHub token. Set GITHUB_TOKEN or GH_TOKEN.');
 
@@ -109,7 +75,6 @@ async function githubGraphQL(query, variables = {}, extraHeaders = {}) {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,
             'User-Agent': 'controleonline-agent-dispatch',
-            ...extraHeaders,
           },
           body: JSON.stringify({ query, variables }),
         });
@@ -139,53 +104,6 @@ async function githubGraphQL(query, variables = {}, extraHeaders = {}) {
       return json.data;
     },
     { label: 'GitHub GraphQL dispatch', ...RETRY }
-  );
-}
-
-async function githubRest(path, options = {}) {
-  const token = getToken();
-  if (!token) throw new Error('Missing GitHub token. Set GITHUB_TOKEN or GH_TOKEN.');
-
-  return retryAsync(
-    async () => {
-      let response;
-      try {
-        response = await fetch(`${REST_API_URL}${path}`, {
-          ...options,
-          headers: {
-            Accept: 'application/vnd.github+json',
-            Authorization: `Bearer ${token}`,
-            'X-GitHub-Api-Version': '2022-11-28',
-            'Content-Type': 'application/json',
-            'User-Agent': 'controleonline-agent-dispatch',
-            ...(options.headers || {}),
-          },
-        });
-      } catch (error) {
-        throw retryableError(`GitHub REST request failed: ${error.message || error}`);
-      }
-
-      const text = await response.text();
-      let body;
-      try {
-        body = text ? JSON.parse(text) : null;
-      } catch {
-        const message = JSON.stringify({ status: response.status, path, body: text }, null, 2);
-        if (isRetriableStatus(response.status)) {
-          throw retryableError(message);
-        }
-        throw new Error(message);
-      }
-      if (!response.ok) {
-        const message = JSON.stringify({ status: response.status, path, body }, null, 2);
-        if (isRetriableStatus(response.status)) {
-          throw retryableError(message);
-        }
-        throw new Error(message);
-      }
-      return body;
-    },
-    { label: `GitHub REST dispatch ${path}`, ...RETRY }
   );
 }
 
@@ -224,37 +142,14 @@ async function getProjectSnapshot(org, projectNumber) {
                 state
                 createdAt
                 updatedAt
-                comments(last:10) {
-                  nodes {
-                    body
-                  }
-                }
                 labels(first:20) {
                   nodes {
                     name
                   }
                 }
-                assignees(first:20) {
-                  nodes {
-                    id
-                    login
-                  }
-                }
                 repository {
                   id
                   nameWithOwner
-                  suggestedActors(capabilities:[CAN_BE_ASSIGNED], first:20) {
-                    nodes {
-                      __typename
-                      login
-                      ... on Bot {
-                        id
-                      }
-                      ... on User {
-                        id
-                      }
-                    }
-                  }
                 }
               }
             }
@@ -297,107 +192,6 @@ function currentAgentLabel(issue) {
   return issueLabels(issue).find((label) => ALL_AGENT_LABELS.includes(label)) || null;
 }
 
-function assigneeLogins(issue) {
-  return (issue.assignees?.nodes || [])
-    .map((assignee) => (assignee?.login || '').trim().toLowerCase())
-    .filter(Boolean);
-}
-
-function serializeAssigneeActors(issue) {
-  return (issue.assignees?.nodes || [])
-    .map((assignee) => ({
-      id: assignee?.id || null,
-      login: (assignee?.login || '').trim().toLowerCase(),
-    }))
-    .filter((assignee) => assignee.login);
-}
-
-function hasAgentAssignee(issue, knownAgentLogins) {
-  return assigneeLogins(issue).some((login) => knownAgentLogins.has(login));
-}
-
-function hasHumanAssignee(issue, knownAgentLogins) {
-  return assigneeLogins(issue).some((login) => !knownAgentLogins.has(login));
-}
-
-function hasHumanOnlyAssignee(issue, knownAgentLogins) {
-  return hasHumanAssignee(issue, knownAgentLogins) && !hasAgentAssignee(issue, knownAgentLogins);
-}
-
-function retainedHumanActorIds(issue, knownAgentLogins) {
-  return (issue.assignees?.nodes || [])
-    .filter((assignee) => {
-      const login = (assignee?.login || '').trim().toLowerCase();
-      return login && !knownAgentLogins.has(login) && assignee?.id;
-    })
-    .map((assignee) => assignee.id);
-}
-
-function technicalAgentLogins(issue, knownAgentLogins) {
-  return [...new Set(
-    (issue.assignees?.nodes || [])
-      .map((assignee) => (assignee?.login || '').trim().toLowerCase())
-      .filter((login) => login && knownAgentLogins.has(login))
-  )];
-}
-
-function isOverrideAssigneeLogin(login, assigneeOverrideLogin) {
-  return Boolean(assigneeOverrideLogin) && login === assigneeOverrideLogin;
-}
-
-function hasRedispatchableAgentAssignee(issue, knownAgentLogins, assigneeOverrideLogin) {
-  return assigneeLogins(issue).some(
-    (login) => knownAgentLogins.has(login) && !isOverrideAssigneeLogin(login, assigneeOverrideLogin)
-  );
-}
-
-function getAssignableActor(issue, preferredAgentLogin) {
-  return (issue.repository?.suggestedActors?.nodes || []).find(
-    (actor) => actor?.login?.toLowerCase() === preferredAgentLogin
-  );
-}
-
-function getAssignedAgentActor(issue, knownAgentLogins, preferredAgentLogin, excludedLogins = new Set()) {
-  const assignees = issue.assignees?.nodes || [];
-  const preferred = assignees.find((assignee) => {
-    const login = (assignee?.login || '').trim().toLowerCase();
-    return assignee?.id && login === preferredAgentLogin && !excludedLogins.has(login);
-  });
-  if (preferred) return preferred;
-
-  return assignees.find((assignee) => {
-    const login = (assignee?.login || '').trim().toLowerCase();
-    return assignee?.id && knownAgentLogins.has(login) && !excludedLogins.has(login);
-  });
-}
-
-function getRedispatchableAssignedAgentActor(issue, knownAgentLogins, preferredAgentLogin, assigneeOverrideLogin) {
-  const excludedLogins = assigneeOverrideLogin ? new Set([assigneeOverrideLogin]) : new Set();
-  return getAssignedAgentActor(issue, knownAgentLogins, preferredAgentLogin, excludedLogins);
-}
-
-function getDispatchActor(issue, knownAgentLogins, preferredAgentLogin) {
-  return getAssignableActor(issue, preferredAgentLogin) || getAssignedAgentActor(issue, knownAgentLogins, preferredAgentLogin);
-}
-
-function recentComments(issue) {
-  return issue.comments?.nodes || [];
-}
-
-function commentMarker(type, role) {
-  return `<!-- cto-mcp-agent-dispatch:${type}:${role} -->`;
-}
-
-function hasCommentMarker(issue, type, role) {
-  return recentComments(issue).some((comment) =>
-    (comment?.body || '').includes(commentMarker(type, role))
-  );
-}
-
-function hasBootstrapComment(issue, role) {
-  return hasCommentMarker(issue, 'bootstrap', role);
-}
-
 function sortByCreatedAt(items) {
   return [...items].sort((left, right) => {
     const leftTs = Date.parse(left.content?.createdAt || '') || 0;
@@ -406,284 +200,32 @@ function sortByCreatedAt(items) {
   });
 }
 
-function minutesSince(value) {
-  const timestamp = Date.parse(value || '');
-  if (!timestamp) return null;
-  return Math.max(0, Math.floor((Date.now() - timestamp) / 60000));
+function statusMatches(status, allowedStatuses) {
+  const normalized = (status || '').trim().toLowerCase();
+  return allowedStatuses.some((entry) => entry.toLowerCase() === normalized);
 }
 
-function isStaleActiveForRole(item, role, knownAgentLogins, staleAfterMinutes, assigneeOverrideLogin) {
-  if (!isActiveForRole(item, role, knownAgentLogins)) return false;
-  if (!hasRedispatchableAgentAssignee(item.content, knownAgentLogins, assigneeOverrideLogin)) return false;
-  const ageMinutes = minutesSince(item.content?.updatedAt);
-  return ageMinutes !== null && ageMinutes >= staleAfterMinutes;
-}
-
-function isBootstrapActiveForRole(item, role, knownAgentLogins, preferredAgentLogin, assigneeOverrideLogin) {
-  if (!isActiveForRole(item, role, knownAgentLogins)) return false;
-  const issue = item.content;
-  const assignedActor = getRedispatchableAssignedAgentActor(
-    issue,
-    knownAgentLogins,
-    preferredAgentLogin,
-    assigneeOverrideLogin
-  );
-  if (!assignedActor?.id) return false;
-  const assignedLogin = (assignedActor.login || '').trim().toLowerCase();
-  if (!assignedLogin || assignedLogin === preferredAgentLogin) return false;
-  return !hasBootstrapComment(issue, role);
-}
-
-function isEligibleForRole(item, role, workStatus, knownAgentLogins) {
+function isEligibleForRole(item, role, workStatuses, deployStatuses) {
   const issue = item.content;
   if (!issue?.repository?.nameWithOwner) return false;
   if (issue.state !== 'OPEN') return false;
 
   const stageLabel = currentAgentLabel(issue);
-  const roleLabel = ROLE_META[role].label;
-  const agentAssigned = hasAgentAssignee(issue, knownAgentLogins);
-  const humanOnlyAssigned = hasHumanOnlyAssignee(issue, knownAgentLogins);
-
-  if (stageLabel === roleLabel) {
-    if (humanOnlyAssigned) return false;
-    return !agentAssigned;
-  }
+  const status = getStatusValue(item);
 
   if (role === 'developer') {
-    const status = getStatusValue(item);
-    if (status?.toLowerCase() !== workStatus.toLowerCase()) return false;
-    if (stageLabel) return false;
-    if (humanOnlyAssigned) return false;
-    return !agentAssigned;
+    return statusMatches(status, workStatuses) && (!stageLabel || stageLabel === ROLE_META.developer.label);
   }
 
-  return false;
+  if (role === 'devops') {
+    return statusMatches(status, deployStatuses) && stageLabel === ROLE_META.devops.label;
+  }
+
+  return statusMatches(status, workStatuses) && stageLabel === ROLE_META[role].label;
 }
 
-function isActiveForRole(item, role, knownAgentLogins) {
+function serializeItem(item) {
   const issue = item.content;
-  if (!issue?.repository?.nameWithOwner) return false;
-  if (issue.state !== 'OPEN') return false;
-  if (!hasAgentAssignee(issue, knownAgentLogins)) return false;
-  return currentAgentLabel(issue) === ROLE_META[role].label;
-}
-
-function buildAgentInstructions(role, issueRef, issueNumber, mode = 'dispatch') {
-  const meta = ROLE_META[role];
-  const agentFile = `.github/agents/${role}.agent.md`;
-  const prefix =
-    mode === 'recovery'
-      ? `Retome a execução travada ou devolvida para o agent ${meta.displayName} na issue ${issueRef}.`
-      : mode === 'bootstrap'
-        ? `Continue a execução já atribuída ao Copilot na issue ${issueRef}, agora seguindo explicitamente o papel ${meta.displayName}.`
-      : `Atue como o agent ${meta.displayName} da ControleOnline para a issue ${issueRef}.`;
-
-  return [
-    prefix,
-    `Antes de agir, leia e siga \`${agentFile}\` no repositório alvo.`,
-    'Leia também o `AGENTS.md` mais específico do código afetado.',
-    `Trabalhe a partir do branch \`task-${issueNumber}\` derivado de \`master\` quando a tarefa exigir mudanças.`,
-    'Use GitHub como fonte de verdade para issue, PR, comentários, branch, labels e evidências.',
-    mode === 'recovery'
-      ? 'Se a issue foi devolvida manualmente, trate isso como correção normal do fluxo; revise o histórico recente e continue sem esperar intervenção humana.'
-      : '',
-    meta.nextInstruction,
-  ]
-    .filter(Boolean)
-    .join(' ');
-}
-
-function buildAssignmentComment(role, issueRef) {
-  const meta = ROLE_META[role];
-  const origin =
-    role === 'developer'
-      ? 'Origem: fila `Work` do ProjectV2'
-      : `Origem: label \`${meta.label}\``;
-
-  return [
-    `### ${meta.commentHeader}`,
-    '',
-    `Issue: ${issueRef}`,
-    origin,
-    'Critério: task elegível, sem ownership exclusivamente humano e pronta para nova captura pelo agent.',
-    `Ação: o runner atribuiu o agent \`${meta.displayName}\` para iniciar a execução.`,
-  ].join('\n');
-}
-
-function buildBootstrapComment(role, issueRef, actorLogin) {
-  const meta = ROLE_META[role];
-  return [
-    `### ${meta.commentHeader} - contexto reaplicado`,
-    '',
-    `Issue: ${issueRef}`,
-    `Origem: issue já estava com o assignee técnico \`${actorLogin}\`, mas ainda precisava receber o contexto personalizado do agent \`${meta.displayName}\`.`,
-    'Ação: o runner reaplicou a atribuição com instruções explícitas do agent para a execução continuar no fluxo correto.',
-    '',
-    commentMarker('bootstrap', role),
-  ].join('\n');
-}
-
-function buildRecoveryComment(role, issueRef, staleAfterMinutes, updatedAt) {
-  const meta = ROLE_META[role];
-  const ageMinutes = minutesSince(updatedAt);
-  return [
-    `### ${meta.commentHeader} - retomada automática`,
-    '',
-    `Issue: ${issueRef}`,
-    `Origem: execução ativa em \`${meta.label}\` sem avanço recente.`,
-    `Critério: issue ainda aberta, com assignee de agent, parada há ${ageMinutes ?? 'tempo indeterminado'} minutos; limite configurado: ${staleAfterMinutes} minutos.`,
-    `Ação: o runner reatribuiu o agent \`${meta.displayName}\` para retomar a execução sem bloquear a continuação da fila.`,
-    '',
-    commentMarker('recovery', role),
-  ].join('\n');
-}
-
-function buildUnavailableComment(role, issueRef, unsupportedLabel) {
-  const meta = ROLE_META[role];
-  return [
-    `### ${meta.commentHeader} - bloqueio operacional`,
-    '',
-    `Issue: ${issueRef}`,
-    `Bloqueio: o repositório alvo não aceita atribuição do Copilot cloud agent para o papel \`${meta.displayName}\`.`,
-    `Ação: a automação marcou a issue com \`${unsupportedLabel}\`, retirou o label \`${meta.label}\` e tentou remover o assignee técnico do Copilot, preservando assignees humanos quando a API do repositório permitiu.`,
-    'Próximo passo: habilitar o Copilot agent neste repositório e depois devolver a task para `Work` ou reaplicar o label do agent correto.',
-    '',
-    commentMarker('unavailable', role),
-  ].join('\n');
-}
-
-function buildOverrideComment(role, issueRef, overrideLogin) {
-  const meta = ROLE_META[role];
-  return [
-    `### ${meta.commentHeader} - modo override`,
-    '',
-    `Issue: ${issueRef}`,
-    `Modo: atribuição manual via \`AGENT_ASSIGNEE_OVERRIDE\` (Copilot cloud agent não disponível no repositório alvo).`,
-    `Ação: o runner atribuiu \`${overrideLogin}\` como responsável pelo papel \`${meta.displayName}\`.`,
-    meta.nextInstruction,
-    '',
-    commentMarker('override', role),
-  ].join('\n');
-}
-
-async function ensureLabelExists(repoFullName, labelName) {
-  const [owner, repo] = repoFullName.split('/');
-  const meta = LABEL_META[labelName] || { color: '1f6feb', description: labelName };
-  try {
-    await githubRest(`/repos/${owner}/${repo}/labels`, {
-      method: 'POST',
-      body: JSON.stringify({
-        name: labelName,
-        color: meta.color,
-        description: meta.description,
-      }),
-    });
-  } catch (error) {
-    const payload = JSON.parse(error.message || '{}');
-    if (payload.status !== 422) throw error;
-  }
-}
-
-async function replaceIssueLabels(repoFullName, issueNumber, nextLabels) {
-  const [owner, repo] = repoFullName.split('/');
-  await githubRest(`/repos/${owner}/${repo}/issues/${issueNumber}/labels`, {
-    method: 'PUT',
-    body: JSON.stringify(nextLabels),
-  });
-}
-
-async function removeIssueAssignees(repoFullName, issueNumber, assignees) {
-  if (!assignees.length) return;
-  const [owner, repo] = repoFullName.split('/');
-  await githubRest(`/repos/${owner}/${repo}/issues/${issueNumber}/assignees`, {
-    method: 'DELETE',
-    body: JSON.stringify({ assignees }),
-  });
-}
-
-async function resolveUserActor(login) {
-  try {
-    const data = await githubRest(`/users/${login}`);
-    if (!data?.node_id) return null;
-    return { id: data.node_id, login: login.toLowerCase() };
-  } catch {
-    return null;
-  }
-}
-
-async function replaceAssignableActors(issueId, actorIds) {
-  return githubGraphQL(
-    `mutation($issueId:ID!, $actorIds:[ID!]!) {
-      replaceActorsForAssignable(input: {
-        assignableId: $issueId,
-        actorIds: $actorIds
-      }) {
-        assignable {
-          ... on Issue {
-            id
-          }
-        }
-      }
-    }`,
-    { issueId, actorIds }
-  );
-}
-
-async function assignIssueToAgent(issueId, actorIds, repositoryId, baseRef, customInstructions, model) {
-  return githubGraphQL(
-    `mutation(
-      $issueId:ID!,
-      $actorIds:[ID!]!,
-      $repositoryId:ID!,
-      $baseRef:String!,
-      $customInstructions:String!,
-      $model:String
-    ) {
-      replaceActorsForAssignable(input: {
-        assignableId: $issueId,
-        actorIds: $actorIds,
-        agentAssignment: {
-          targetRepositoryId: $repositoryId,
-          baseRef: $baseRef,
-          customInstructions: $customInstructions,
-          model: $model
-        }
-      }) {
-        assignable {
-          ... on Issue {
-            id
-          }
-        }
-      }
-    }`,
-    { issueId, actorIds, repositoryId, baseRef, customInstructions, model: model || null },
-    {
-      'GraphQL-Features': 'issues_copilot_assignment_api_support,coding_agent_model_selection',
-    }
-  );
-}
-
-async function addIssueComment(issueId, body) {
-  return githubGraphQL(
-    `mutation($subjectId:ID!, $body:String!) {
-      addComment(input:{subjectId:$subjectId, body:$body}) {
-        commentEdge {
-          node {
-            id
-          }
-        }
-      }
-    }`,
-    { subjectId: issueId, body }
-  );
-}
-
-function serializeItem(item, knownAgentLogins, preferredAgentLogin, staleAfterMinutes = null) {
-  const issue = item.content;
-  const suggestedActor = getAssignableActor(issue, preferredAgentLogin);
-  const assignedAgentActor = getAssignedAgentActor(issue, knownAgentLogins, preferredAgentLogin);
-  const actor = suggestedActor || assignedAgentActor;
-  const ageMinutes = minutesSince(issue.updatedAt);
   return {
     issue: {
       id: issue.id,
@@ -693,24 +235,11 @@ function serializeItem(item, knownAgentLogins, preferredAgentLogin, staleAfterMi
       state: issue.state,
       createdAt: issue.createdAt,
       updatedAt: issue.updatedAt,
-      ageMinutes,
     },
     projectItemId: item.id,
     currentProjectStatus: getStatusValue(item),
     labels: issueLabels(issue),
     currentAgentLabel: currentAgentLabel(issue),
-    assignees: assigneeLogins(issue),
-    assigneeActors: serializeAssigneeActors(issue),
-    suggestedActors: (issue.repository?.suggestedActors?.nodes || [])
-      .map((candidate) => candidate?.login)
-      .filter(Boolean),
-    hasAgentAssignee: hasAgentAssignee(issue, knownAgentLogins),
-    hasHumanAssignee: hasHumanAssignee(issue, knownAgentLogins),
-    hasHumanOnlyAssignee: hasHumanOnlyAssignee(issue, knownAgentLogins),
-    canAssignPreferredAgent: Boolean(actor?.id),
-    dispatchActorSource: suggestedActor ? 'suggestedActors' : assignedAgentActor ? 'currentAgentAssignee' : null,
-    staleAfterMinutes,
-    isStale: staleAfterMinutes ? ageMinutes !== null && ageMinutes >= staleAfterMinutes : null,
   };
 }
 
@@ -728,54 +257,15 @@ async function main() {
   const org = env('AGENT_PROJECT_ORG', 'ControleOnline');
   const projectNumber = Number(env('AGENT_PROJECT_NUMBER', '1'));
   const dryRun = env('AGENT_DRY_RUN', 'true').toLowerCase() !== 'false';
-  const workStatus = env('AGENT_WORK_STATUS', 'Work');
-  const preferredAgentLogin = env('AGENT_LOGIN', DEFAULT_AGENT_LOGIN).toLowerCase();
-  const knownAgentLogins = new Set(
-    parseCsv(env('AGENT_KNOWN_LOGINS', DEFAULT_KNOWN_AGENT_LOGINS)).map((login) => login.toLowerCase())
-  );
-  const baseRef = env('AGENT_COPILOT_BASE_REF', 'master');
-  const model = env('AGENT_COPILOT_MODEL');
-  const staleAfterMinutes = parsePositiveNumber(env('AGENT_STALE_AFTER_MINUTES', DEFAULT_STALE_AFTER_MINUTES), 30);
-  const redispatchStaleActive = env('AGENT_REDISPATCH_STALE_ACTIVE', 'true').toLowerCase() !== 'false';
-  const unsupportedLabel = env('AGENT_UNSUPPORTED_LABEL', DEFAULT_UNSUPPORTED_LABEL);
-
-  const assigneeOverrideLogin = env('AGENT_ASSIGNEE_OVERRIDE', '').toLowerCase();
-  let overrideActor = null;
-  if (assigneeOverrideLogin) {
-    overrideActor = await resolveUserActor(assigneeOverrideLogin);
-    if (overrideActor) {
-      knownAgentLogins.add(assigneeOverrideLogin);
-    }
-  }
+  const workStatuses = parseCsv(env('AGENT_WORK_STATUSES', 'Work,Working'));
+  const deployStatuses = parseCsv(env('AGENT_DEPLOY_STATUSES', 'Deploy'));
 
   const data = await getProjectSnapshot(org, projectNumber);
   const project = data?.organization?.projectV2;
   if (!project) throw new Error(`Project not found: ${org}/projects/${projectNumber}`);
 
   const items = sortByCreatedAt(project.items?.nodes || []);
-  const hasUnsupportedLabel = (item) => issueLabels(item.content).includes(unsupportedLabel);
-  const unsupportedItems = items.filter((item) => hasUnsupportedLabel(item));
-  const activeItems = items.filter(
-    (item) => !hasUnsupportedLabel(item) && isActiveForRole(item, role, knownAgentLogins)
-  );
-  const bootstrapActiveItems = activeItems.filter((item) =>
-    isBootstrapActiveForRole(item, role, knownAgentLogins, preferredAgentLogin, assigneeOverrideLogin)
-  );
-  const staleActiveItems = redispatchStaleActive
-    ? activeItems.filter((item) =>
-        isStaleActiveForRole(item, role, knownAgentLogins, staleAfterMinutes, assigneeOverrideLogin)
-      )
-    : [];
-  const bootstrapActiveIds = new Set(bootstrapActiveItems.map((item) => item.id));
-  const staleActiveIds = new Set(staleActiveItems.map((item) => item.id));
-  const freshActiveItems = activeItems.filter(
-    (item) => !staleActiveIds.has(item.id) && !bootstrapActiveIds.has(item.id)
-  );
-  const candidateItems = items.filter(
-    (item) =>
-      (!hasUnsupportedLabel(item) || overrideActor) && isEligibleForRole(item, role, workStatus, knownAgentLogins)
-  );
-  const targetItems = [...bootstrapActiveItems, ...staleActiveItems, ...candidateItems];
+  const candidateItems = items.filter((item) => isEligibleForRole(item, role, workStatuses, deployStatuses));
 
   const result = {
     generatedAt: new Date().toISOString(),
@@ -787,200 +277,41 @@ async function main() {
       id: project.id,
       title: project.title,
     },
-    workStatus,
     roleLabel: meta.label,
-    unsupportedLabel,
-    staleAfterMinutes,
-    redispatchStaleActive,
-    activeCount: activeItems.length,
-    bootstrapActiveCount: bootstrapActiveItems.length,
-    freshActiveCount: freshActiveItems.length,
-    staleActiveCount: staleActiveItems.length,
-    unsupportedCount: unsupportedItems.length,
+    workStatuses,
+    deployStatuses,
     candidateCount: candidateItems.length,
-    activeItems: activeItems.map((item) => serializeItem(item, knownAgentLogins, preferredAgentLogin, staleAfterMinutes)),
-    staleActiveItems: staleActiveItems.map((item) => serializeItem(item, knownAgentLogins, preferredAgentLogin, staleAfterMinutes)),
-    unsupportedItems: unsupportedItems.map((item) => serializeItem(item, knownAgentLogins, preferredAgentLogin, staleAfterMinutes)),
-    candidateItems: candidateItems.map((item) => serializeItem(item, knownAgentLogins, preferredAgentLogin, staleAfterMinutes)),
-    assignmentAttempts: [],
+    candidateItems: candidateItems.map((item) => serializeItem(item)),
+    selectedItem: candidateItems.length > 0 ? serializeItem(candidateItems[0]) : null,
   };
 
-  if (targetItems.length === 0) {
+  if (candidateItems.length === 0) {
     result.ok = true;
     result.skipped = true;
-    result.reason = `Nenhuma task elegível ou execução travada foi encontrada para ${meta.displayName}.`;
+    result.reason = `Nenhuma task elegivel por tags e coluna foi encontrada para ${meta.displayName}.`;
     const outPath = writeOutputFile(result);
     console.log(JSON.stringify({ ok: true, skipped: true, reason: result.reason, outPath }, null, 2));
     return;
   }
 
-  for (const target of targetItems) {
-    const issue = target.content;
-    const issueRef = `${issue.repository.nameWithOwner}#${issue.number}`;
-    const rawActor = getDispatchActor(issue, knownAgentLogins, preferredAgentLogin);
-    const isOverride = !rawActor?.id && Boolean(overrideActor?.id);
-    const actor = rawActor || (isOverride ? overrideActor : null);
-    const targetRecord = serializeItem(target, knownAgentLogins, preferredAgentLogin, staleAfterMinutes);
-    const mode = bootstrapActiveIds.has(target.id)
-      ? 'bootstrap'
-      : staleActiveIds.has(target.id)
-        ? 'recovery'
-        : 'dispatch';
-
-    if (!actor?.id) {
-      result.assignmentAttempts.push({
-        issue: targetRecord.issue,
-        status: 'skipped',
-        reason: `O agent ${preferredAgentLogin} não apareceu em suggestedActors nem como assignee atual de agent para ${issue.repository.nameWithOwner}.`,
-        suggestedActors: targetRecord.suggestedActors,
-        assignees: targetRecord.assignees,
-      });
-      continue;
-    }
-
-    const currentLabels = issueLabels(issue);
-    const labelsToStrip = isOverride
-      ? [...ALL_AGENT_LABELS, unsupportedLabel]
-      : ALL_AGENT_LABELS;
-    const nextLabels = [...new Set([...currentLabels.filter((label) => !labelsToStrip.includes(label)), meta.label])];
-    const blockedLabels = [
-      ...new Set([...currentLabels.filter((label) => !ALL_AGENT_LABELS.includes(label)), unsupportedLabel]),
-    ];
-    const preservedHumanActorIds = retainedHumanActorIds(issue, knownAgentLogins);
-    const technicalAgentAssignees = technicalAgentLogins(issue, knownAgentLogins);
-    const nextActorIds = [...new Set([actor.id, ...preservedHumanActorIds])];
-
-    result.selectedItem = targetRecord;
-    result.selectedMode = mode;
-
-    try {
-      if (!dryRun) {
-        await ensureLabelExists(issue.repository.nameWithOwner, meta.label);
-        await replaceIssueLabels(issue.repository.nameWithOwner, issue.number, nextLabels);
-        if (isOverride) {
-          await replaceAssignableActors(issue.id, nextActorIds);
-          if (!hasCommentMarker(issue, 'override', role)) {
-            await addIssueComment(issue.id, buildOverrideComment(role, issueRef, actor.login));
-          }
-        } else {
-          await assignIssueToAgent(
-            issue.id,
-            nextActorIds,
-            issue.repository.id,
-            baseRef,
-            buildAgentInstructions(role, issueRef, issue.number, mode),
-            model
-          );
-          const shouldComment =
-            mode === 'dispatch' ||
-            !hasCommentMarker(issue, mode === 'bootstrap' ? 'bootstrap' : 'recovery', role);
-          if (shouldComment) {
-            await addIssueComment(
-              issue.id,
-              mode === 'bootstrap'
-                ? buildBootstrapComment(role, issueRef, actor.login || preferredAgentLogin)
-                : mode === 'recovery'
-                ? buildRecoveryComment(role, issueRef, staleAfterMinutes, issue.updatedAt)
-                : buildAssignmentComment(role, issueRef)
-            );
-          }
-        }
-        result.executed = true;
-      } else {
-        result.executed = false;
-        result.previewComment = isOverride
-          ? buildOverrideComment(role, issueRef, actor.login)
-          : mode === 'bootstrap'
-            ? buildBootstrapComment(role, issueRef, actor.login || preferredAgentLogin)
-            : mode === 'recovery'
-              ? buildRecoveryComment(role, issueRef, staleAfterMinutes, issue.updatedAt)
-              : buildAssignmentComment(role, issueRef);
-        result.previewInstructions = isOverride
-          ? null
-          : buildAgentInstructions(role, issueRef, issue.number, mode);
-        result.previewLabels = nextLabels;
-        result.previewActorIds = nextActorIds;
-      }
-    } catch (error) {
-      if (!dryRun && isCopilotUnavailableError(error)) {
-        await ensureLabelExists(issue.repository.nameWithOwner, unsupportedLabel);
-        await replaceIssueLabels(issue.repository.nameWithOwner, issue.number, blockedLabels);
-        let clearedAgentAssignee = false;
-        const cleanupWarnings = [];
-        try {
-          await replaceAssignableActors(issue.id, preservedHumanActorIds);
-          clearedAgentAssignee = true;
-        } catch (cleanupError) {
-          cleanupWarnings.push(cleanupError.message || String(cleanupError || ''));
-        }
-        if (technicalAgentAssignees.length > 0) {
-          try {
-            await removeIssueAssignees(issue.repository.nameWithOwner, issue.number, technicalAgentAssignees);
-            clearedAgentAssignee = true;
-          } catch (cleanupError) {
-            cleanupWarnings.push(cleanupError.message || String(cleanupError || ''));
-          }
-        }
-        if (cleanupWarnings.length > 0) {
-          result.assignmentCleanupWarning = cleanupWarnings.join(' | ');
-        }
-        if (!hasCommentMarker(issue, 'unavailable', role)) {
-          await addIssueComment(issue.id, buildUnavailableComment(role, issueRef, unsupportedLabel));
-        }
-        result.assignmentAttempts.push({
-          issue: targetRecord.issue,
-          status: 'blocked',
-          reason: `Repositório sem suporte à atribuição do Copilot cloud agent; issue marcada com ${unsupportedLabel}.`,
-          dispatchActorSource: targetRecord.dispatchActorSource,
-          cleanupClearedAgentAssignee: clearedAgentAssignee,
-        });
-        continue;
-      }
-      throw error;
-    }
-
-    result.ok = true;
-    result.assignedIssue = issueRef;
-    result.assignedAgent = actor.login || preferredAgentLogin;
-    result.baseRef = baseRef;
-    result.dispatchActorSource = isOverride ? 'overrideAssignee' : targetRecord.dispatchActorSource;
-    result.assignmentAttempts.push({
-      issue: targetRecord.issue,
-      status: dryRun ? 'preview' : mode === 'bootstrap' ? 'bootstrapped' : mode === 'recovery' ? 'redispatched' : 'assigned',
-      reason:
-        mode === 'bootstrap'
-          ? 'Execução técnica já aberta recebeu o contexto explícito do agent.'
-          : mode === 'recovery'
-            ? 'Primeira execução travada e atribuível encontrada para retomada automática.'
-            : 'Primeira task elegível e atribuível encontrada.',
-      dispatchActorSource: isOverride ? 'overrideAssignee' : targetRecord.dispatchActorSource,
-    });
-
-    const outPath = writeOutputFile(result);
-    console.log(
-      JSON.stringify(
-        {
-          ok: true,
-          dryRun,
-          role,
-          mode,
-          assignedIssue: issueRef,
-          assignedAgent: actor.login || preferredAgentLogin,
-          dispatchActorSource: isOverride ? 'overrideAssignee' : targetRecord.dispatchActorSource,
-          outPath,
-        },
-        null,
-        2
-      )
-    );
-    return;
-  }
-
-  result.ok = false;
-  result.skipped = true;
-  result.reason = `Nenhuma task elegível ou execução travada pôde ser atribuída ao agent ${meta.displayName}.`;
+  result.ok = true;
+  result.discoveryMode = 'labels-and-columns-only';
+  result.reason = 'Selecao concluida sem uso de assignee, fallback tecnico ou comentario automatico.';
   const outPath = writeOutputFile(result);
-  console.log(JSON.stringify({ ok: false, skipped: true, reason: result.reason, outPath }, null, 2));
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        dryRun,
+        role,
+        selectedIssue: result.selectedItem?.issue?.ref || null,
+        discoveryMode: result.discoveryMode,
+        outPath,
+      },
+      null,
+      2
+    )
+  );
 }
 
 main().catch((error) => {

--- a/skills/shared/README.md
+++ b/skills/shared/README.md
@@ -63,8 +63,8 @@ Esta pasta tambem concentra skills operacionais reutilizaveis:
 
 Valide sempre:
 
-- label `agent:*`
-- assignee tecnico versus assignees humanos
+- tags `agent:*` relevantes para a etapa atual
+- coluna real da issue
 - PR vinculado
 - conflito de merge
 - checks
@@ -72,10 +72,14 @@ Valide sempre:
 
 Regras centrais:
 
-- task em `Work` sem `agent:*` entra por `Developer`
-- conflito de merge em PR aberto no mesmo repositorio desvia para `DevOps`
-- `ops:copilot-unavailable` com PR aberto nao e fila virgem
-- `override manual ativo` nao deve ser lido como captura first-party do Copilot
+- task em `Work` ou `Working` sem `agent:*` entra por `Developer`
+- nenhum agent pode usar assignee como mecanismo de captura, redispatch ou fallback
+- `Developer`, `Security`, `Quality Assurance` e `Sysadmin` leem a fila em `Work` ou `Working`
+- `DevOps` le a fila em `Deploy`
+- agents documentais externos ao nucleo, como `Documentor`, leem a fila em `Done`
+- bloqueio de infraestrutura vira issue separada com tag `agent:sysadmin` em `Work`
+- conflito de merge em PR aberto no mesmo repositorio desvia a trilha para `DevOps`
+- depois das etapas de `Developer`, `Security` e `Quality Assurance`, qualquer agent com evidencia suficiente pode mover a task para `In Review`
 
 ## Execution Priority Policy
 

--- a/skills/shared/README.md
+++ b/skills/shared/README.md
@@ -74,6 +74,8 @@ Regras centrais:
 
 - task em `Work` ou `Working` sem `agent:*` entra por `Developer`
 - nenhum agent pode usar assignee como mecanismo de captura, redispatch ou fallback
+- nenhum agent pode fechar task; fechamento em `closed` pertence apenas a humanos
+- para os agents, o estado operacional valido e definido por coluna e tags, nao por `open` ou `closed`
 - `Developer`, `Security`, `Quality Assurance` e `Sysadmin` leem a fila em `Work` ou `Working`
 - `DevOps` le a fila em `Deploy`
 - agents documentais externos ao nucleo, como `Documentor`, leem a fila em `Done`

--- a/skills/shared/agent-handoff-governance.md
+++ b/skills/shared/agent-handoff-governance.md
@@ -2,30 +2,32 @@
 
 ## Overview
 
-Use esta skill para padronizar ownership, transicao de label, handoff tecnico e desvio operacional entre agents.
+Use esta skill para padronizar tags, transicao de etapa, handoff tecnico e desvio operacional entre agents.
 
 ## Workflow
 
-1. confirme o label `agent:*` atual e o estado real da issue, do PR e dos checks
-2. se a task estiver em `Work` sem `agent:*`, a entrada padrao e `Developer`
-3. cada agent so troca o label quando sua propria etapa estiver realmente concluida
-4. se houver conflito de merge em PR aberto, a responsabilidade operacional vai para `DevOps`
-5. `DevOps` e o unico que move a task para `In Review`
-6. `Sysadmin` pode manter acompanhamento operacional em `Work` e abrir etapa de validacao em `In Review` quando houver necessidade posterior
-7. nao faca handoff sem evidencia concreta do que foi validado, corrigido ou bloqueado
+1. confirme as tags `agent:*` atuais, a coluna real da issue, o PR e os checks
+2. nunca atribua a task a pessoas, bots ou fallbacks tecnicos; assignee nao faz parte do fluxo
+3. se a task estiver em `Work` ou `Working` sem `agent:*`, a entrada padrao e `Developer`
+4. cada agent so troca a tag quando sua propria etapa estiver realmente concluida
+5. se houver bloqueio de infraestrutura que impeça a continuidade, abra ou atualize uma issue separada em `Work` com tag `agent:sysadmin` e referencie a issue bloqueada
+6. `Developer`, `Security`, `Quality Assurance` e `Sysadmin` trabalham em `Work` ou `Working`; `DevOps` trabalha em `Deploy`; agents documentais externos ao nucleo, como `Documentor`, trabalham em `Done`
+7. depois que a trilha tiver passado por `Developer`, `Security` e `Quality Assurance`, qualquer agent com evidencia concreta pode mover a task para `In Review`
+8. nao faca handoff sem evidencia concreta do que foi validado, corrigido ou bloqueado
 
 ## Output Contract
 
 Ao concluir, informe objetivamente:
 
-- qual agent era o responsavel atual
-- se houve manutencao ou troca de ownership
+- qual era a tag operacional atual
+- se houve manutencao ou troca de tag
 - qual evidencia sustentou o handoff ou o bloqueio
 - qual proxima etapa ficou definida
 
 ## Quality Bar
 
 - nao retenha task na fila errada
+- nao use assignee como atalho de ownership
 - nao trate conflito de merge como detalhe secundario quando ele bloqueia o fluxo
 - nao mova tarefa por aproximacao textual ou intuicao
 - nao esconda pendencia operacional no momento do handoff

--- a/skills/shared/agent-handoff-governance.md
+++ b/skills/shared/agent-handoff-governance.md
@@ -8,12 +8,13 @@ Use esta skill para padronizar tags, transicao de etapa, handoff tecnico e desvi
 
 1. confirme as tags `agent:*` atuais, a coluna real da issue, o PR e os checks
 2. nunca atribua a task a pessoas, bots ou fallbacks tecnicos; assignee nao faz parte do fluxo
-3. se a task estiver em `Work` ou `Working` sem `agent:*`, a entrada padrao e `Developer`
-4. cada agent so troca a tag quando sua propria etapa estiver realmente concluida
-5. se houver bloqueio de infraestrutura que impeça a continuidade, abra ou atualize uma issue separada em `Work` com tag `agent:sysadmin` e referencie a issue bloqueada
-6. `Developer`, `Security`, `Quality Assurance` e `Sysadmin` trabalham em `Work` ou `Working`; `DevOps` trabalha em `Deploy`; agents documentais externos ao nucleo, como `Documentor`, trabalham em `Done`
-7. depois que a trilha tiver passado por `Developer`, `Security` e `Quality Assurance`, qualquer agent com evidencia concreta pode mover a task para `In Review`
-8. nao faca handoff sem evidencia concreta do que foi validado, corrigido ou bloqueado
+3. agentes nao fecham tasks; so humanos podem mover a issue para `closed`
+4. se a task estiver em `Work` ou `Working` sem `agent:*`, a entrada padrao e `Developer`
+5. cada agent so troca a tag ou a coluna quando sua propria etapa estiver realmente concluida
+6. se houver bloqueio de infraestrutura que impeça a continuidade, abra ou atualize uma issue separada em `Work` com tag `agent:sysadmin` e referencie a issue bloqueada
+7. `Developer`, `Security`, `Quality Assurance` e `Sysadmin` trabalham em `Work` ou `Working`; `DevOps` trabalha em `Deploy`; agents documentais externos ao nucleo, como `Documentor`, trabalham em `Done`
+8. depois que a trilha tiver passado por `Developer`, `Security` e `Quality Assurance`, qualquer agent com evidencia concreta pode mover a task para `In Review`
+9. nao faca handoff sem evidencia concreta do que foi validado, corrigido ou bloqueado
 
 ## Output Contract
 
@@ -22,7 +23,7 @@ Ao concluir, informe objetivamente:
 - qual era a tag operacional atual
 - se houve manutencao ou troca de tag
 - qual evidencia sustentou o handoff ou o bloqueio
-- qual proxima etapa ficou definida
+- qual proxima etapa ficou definida pela coluna ou pela tag
 
 ## Quality Bar
 

--- a/skills/shared/github-issue-handling.md
+++ b/skills/shared/github-issue-handling.md
@@ -18,7 +18,7 @@ Ela cobre:
 
 Ao interagir com GitHub para gestao operacional, issues, acompanhamento, organizacao de trabalho ou consulta de estruturas de projeto:
 
-- nao use ProjectV2
+- nao use assignee como mecanismo de captura, triagem ou ownership
 - quando precisar consultar, relacionar, organizar ou atualizar informacoes equivalentes de projeto no GitHub, prefira GraphQL quando ele estiver disponivel e funcional na sessao
 - se GraphQL estiver bloqueado por limitacao de infraestrutura, rede, proxy, egress, autenticacao da sessao ou erro 403 semelhante, faca fallback para acoes e rotas do GitHub disponiveis no agent
 - trate o app do GitHub conectado ao agent como caminho principal para operacoes no GitHub
@@ -53,24 +53,27 @@ Ao checar GitHub Actions:
 
 1. antes de abrir nova issue, verifique se ja existe acompanhamento claro para o mesmo assunto
 2. se ja existir issue, investigacao, pull request ou acompanhamento equivalente, prefira atualizar, comentar ou referenciar em vez de duplicar
-3. nunca atribua responsavel, salvo regra explicita futura
+3. nunca atribua responsavel
 4. nunca exponha credenciais, segredos, tokens, conteudo sensivel de arquivos de ambiente, dados pessoais ou trechos sensiveis de logs
 5. se citar logs, resuma ou sanitize o conteudo
 6. registre contexto suficiente para entendimento tecnico, rastreabilidade e continuidade operacional
+7. quando outro agent ficar bloqueado por infraestrutura, abra ou atualize uma issue separada em `Work` com tag `agent:sysadmin`, referencie a issue original e descreva apenas o bloqueio operacional necessario para destravar a trilha
 
 ## Column Policy
 
 Use as colunas desta forma:
 
-- problemas operacionais, de desenvolvimento, de seguranca e demais encaminhamentos de trabalho devem ir para a coluna `Work`
+- problemas operacionais, de desenvolvimento, de seguranca e demais encaminhamentos de trabalho devem ir para a coluna `Work` ou `Working`
 - itens que existem para validacao manual posterior devem ir para a coluna `In Review`
+- tarefas de `DevOps` devem ser lidas na coluna `Deploy`
+- agents documentais externos ao nucleo, como `Documentor`, leem suas tasks na coluna `Done`
 - nao use coluna `Security` neste fluxo
 
 ## Classification Rules
 
 ### Work
 
-Use a coluna `Work` quando houver:
+Use a coluna `Work` ou `Working` quando houver:
 
 - bug
 - regressao
@@ -79,6 +82,7 @@ Use a coluna `Work` quando houver:
 - comportamento incorreto de codigo
 - incidente operacional que precise acompanhamento tecnico
 - indicio de problema de seguranca, vulnerabilidade, exposicao indevida, comportamento suspeito, acesso anomalo ou possivel incidente
+- bloqueio de infraestrutura que precise acompanhamento do `Sysadmin`
 
 Em casos de seguranca, mantenha a issue em `Work`, mas reduza detalhes exploraveis e preserve somente o contexto seguro necessario.
 
@@ -94,17 +98,18 @@ Use a coluna `In Review` quando houver:
 
 Ao criar ou atualizar issues:
 
-- use labels compativeis com o papel de sysadmin e com a natureza do problema
+- use tags compativeis com o papel responsavel pela proxima etapa
+- para bloqueio de infraestrutura, prefira `agent:sysadmin`
 - combine labels de papel com labels de tipo de problema quando isso ajudar a triagem
 - nao invente labels que nao existam
-- se a lista de labels disponivel nao estiver clara, siga sem label em vez de presumir uma label inexistente
+- se a lista de labels disponivel nao estiver clara, siga sem label adicional em vez de presumir uma label inexistente
 
 ## Security Handling Inside GitHub
 
 Quando houver indicio de problema de seguranca:
 
 - faca o registro no GitHub por esta skill, sem criar fluxo separado fora dela
-- coloque a issue em `Work`
+- coloque a issue em `Work` ou `Working`
 - descreva risco, impacto potencial, sintomas observados, escopo afetado e evidencias nao sensiveis
 - omita detalhes que aumentem risco de exploracao ou revelem segredos desnecessariamente
 - preserve rastreabilidade suficiente para continuidade da investigacao
@@ -115,7 +120,7 @@ Ao concluir, entregue um resumo operacional curto com:
 
 - issue criada, atualizada ou referenciada
 - coluna aplicada
-- labels aplicadas, quando houver
+- tags aplicadas, quando houver
 - motivo da classificacao
 - limitacao tecnica relevante, se houve fallback no acesso ao GitHub
 - indicacao de validacao manual pendente, quando existir
@@ -124,9 +129,8 @@ Ao concluir, entregue um resumo operacional curto com:
 ## Quality Bar
 
 - nao duplique issues sem necessidade
-- nao use ProjectV2
+- nao atribua responsavel por padrao nem por excecao
 - nao use a coluna `Security`
-- nao atribua responsavel por padrao
 - nao exponha dados sensiveis
 - nao trate GitHub como substituto do estado real do ambiente
 - sempre mantenha tudo relacionado a GitHub centralizado nesta skill

--- a/skills/shared/github-issue-handling.md
+++ b/skills/shared/github-issue-handling.md
@@ -19,6 +19,7 @@ Ela cobre:
 Ao interagir com GitHub para gestao operacional, issues, acompanhamento, organizacao de trabalho ou consulta de estruturas de projeto:
 
 - nao use assignee como mecanismo de captura, triagem ou ownership
+- nao feche issues em nome de agents; `closed` pertence apenas a humanos
 - quando precisar consultar, relacionar, organizar ou atualizar informacoes equivalentes de projeto no GitHub, prefira GraphQL quando ele estiver disponivel e funcional na sessao
 - se GraphQL estiver bloqueado por limitacao de infraestrutura, rede, proxy, egress, autenticacao da sessao ou erro 403 semelhante, faca fallback para acoes e rotas do GitHub disponiveis no agent
 - trate o app do GitHub conectado ao agent como caminho principal para operacoes no GitHub
@@ -130,6 +131,7 @@ Ao concluir, entregue um resumo operacional curto com:
 
 - nao duplique issues sem necessidade
 - nao atribua responsavel por padrao nem por excecao
+- nao feche issues como substituto de mudanca de coluna ou tag
 - nao use a coluna `Security`
 - nao exponha dados sensiveis
 - nao trate GitHub como substituto do estado real do ambiente

--- a/src/agent-dispatch-runner.js
+++ b/src/agent-dispatch-runner.js
@@ -3,140 +3,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 
-const GRAPHQL_API_URL = 'https://api.github.com/graphql';
-const REST_API_URL = 'https://api.github.com';
-const DEFAULT_UNSUPPORTED_LABEL = 'ops:copilot-unavailable';
-const DEFAULT_KNOWN_AGENT_LOGINS = 'github-copilot[bot],copilot-swe-agent,copilot';
-const ROLE_META = {
-  developer: { displayName: 'Developer', label: 'agent:developer' },
-  security: { displayName: 'Security', label: 'agent:security' },
-  qa: { displayName: 'Quality Assurance', label: 'agent:qa' },
-  devops: { displayName: 'DevOps', label: 'agent:devops' },
-};
-const ALL_AGENT_LABELS = Object.values(ROLE_META).map((entry) => entry.label);
-const LABEL_META = {
-  'ops:copilot-unavailable': {
-    color: 'd4a72c',
-    description: 'Copilot cloud agent nao habilitado no repositorio alvo',
-  },
-};
-
 function env(name, fallback = '') {
   return (process.env[name] || fallback).trim();
-}
-
-function getToken() {
-  return env('GITHUB_TOKEN') || env('GH_TOKEN');
-}
-
-function parseCsv(value) {
-  return value
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean);
-}
-
-function headers(extra = {}) {
-  return {
-    Accept: 'application/vnd.github+json',
-    Authorization: `Bearer ${getToken()}`,
-    'X-GitHub-Api-Version': '2022-11-28',
-    'Content-Type': 'application/json',
-    'User-Agent': 'controleonline-agent-runner',
-    ...extra,
-  };
-}
-
-async function githubRest(pathname, options = {}) {
-  const response = await fetch(`${REST_API_URL}${pathname}`, {
-    ...options,
-    headers: headers(options.headers || {}),
-  });
-  const text = await response.text();
-  const body = text ? JSON.parse(text) : null;
-  if (!response.ok) {
-    throw new Error(JSON.stringify({ status: response.status, path: pathname, body }, null, 2));
-  }
-  return body;
-}
-
-async function githubGraphQL(query, variables = {}) {
-  const response = await fetch(GRAPHQL_API_URL, {
-    method: 'POST',
-    headers: headers({
-      'GraphQL-Features': 'issues_copilot_assignment_api_support,coding_agent_model_selection',
-    }),
-    body: JSON.stringify({ query, variables }),
-  });
-  const json = await response.json();
-  if (!response.ok || json.errors) {
-    throw new Error(JSON.stringify({ status: response.status, errors: json.errors || json }, null, 2));
-  }
-  return json.data;
-}
-
-async function ensureLabelExists(repoFullName, labelName) {
-  const [owner, repo] = repoFullName.split('/');
-  const meta = LABEL_META[labelName] || { color: '1f6feb', description: labelName };
-  try {
-    await githubRest(`/repos/${owner}/${repo}/labels`, {
-      method: 'POST',
-      body: JSON.stringify({
-        name: labelName,
-        color: meta.color,
-        description: meta.description,
-      }),
-    });
-  } catch (error) {
-    const payload = JSON.parse(error.message || '{}');
-    if (payload.status !== 422) throw error;
-  }
-}
-
-async function replaceIssueLabels(repoFullName, issueNumber, nextLabels) {
-  const [owner, repo] = repoFullName.split('/');
-  await githubRest(`/repos/${owner}/${repo}/issues/${issueNumber}/labels`, {
-    method: 'PUT',
-    body: JSON.stringify(nextLabels),
-  });
-}
-
-async function removeIssueAssignees(repoFullName, issueNumber, assignees) {
-  if (!assignees.length) return;
-  const [owner, repo] = repoFullName.split('/');
-  await githubRest(`/repos/${owner}/${repo}/issues/${issueNumber}/assignees`, {
-    method: 'DELETE',
-    body: JSON.stringify({ assignees }),
-  });
-}
-
-async function replaceAssignableActors(issueId, actorIds) {
-  await githubGraphQL(
-    `mutation($issueId:ID!, $actorIds:[ID!]!) {
-      replaceActorsForAssignable(input: {
-        assignableId: $issueId,
-        actorIds: $actorIds
-      }) {
-        assignable {
-          ... on Issue {
-            id
-          }
-        }
-      }
-    }`,
-    { issueId, actorIds }
-  );
-}
-
-async function addIssueComment(issueId, body) {
-  await githubGraphQL(
-    `mutation($subjectId:ID!, $body:String!) {
-      addComment(input:{subjectId:$subjectId, body:$body}) {
-        commentEdge { node { id } }
-      }
-    }`,
-    { subjectId: issueId, body }
-  );
 }
 
 function outputPathForRole(role) {
@@ -166,110 +34,6 @@ function runDispatchScript(role) {
   });
 }
 
-function buildUnavailableComment(role, issueRef, unsupportedLabel, preferredAgentLogin) {
-  const meta = ROLE_META[role] || { displayName: role, label: `agent:${role}` };
-  return [
-    `### ${meta.displayName} iniciado - bloqueio operacional`,
-    '',
-    `Issue: ${issueRef}`,
-    `Bloqueio: o repositório alvo não expôs o actor \`${preferredAgentLogin}\` em \`suggestedActors\` e também não havia assignee atual de agent reaproveitável para o papel \`${meta.displayName}\`.`,
-    `Ação: a automação marcou a issue com \`${unsupportedLabel}\`, retirou o label \`${meta.label}\` e tentou remover o assignee técnico do Copilot, preservando assignees humanos quando a API do repositório permitiu.`,
-    'Próximo passo: habilitar o Copilot agent no repositório alvo e depois devolver a task para `Work` ou reaplicar o label do agent correto.',
-  ].join('\n');
-}
-
-function shouldSurfaceMissingActor(attempt) {
-  return (
-    attempt?.status === 'skipped' &&
-    typeof attempt?.reason === 'string' &&
-    attempt.reason.includes('não apareceu em suggestedActors')
-  );
-}
-
-function retainedHumanActorIdsFromSerialized(detail, knownAgentLogins) {
-  return (detail?.assigneeActors || [])
-    .filter((assignee) => {
-      const login = (assignee?.login || '').trim().toLowerCase();
-      return login && !knownAgentLogins.has(login) && assignee?.id;
-    })
-    .map((assignee) => assignee.id);
-}
-
-function technicalAgentLoginsFromSerialized(detail, knownAgentLogins) {
-  return [...new Set(
-    (detail?.assigneeActors || [])
-      .map((assignee) => (assignee?.login || '').trim().toLowerCase())
-      .filter((login) => login && knownAgentLogins.has(login))
-  )];
-}
-
-async function surfaceMissingActorBlocks(payload) {
-  if (payload?.dryRun) return [];
-
-  const unsupportedLabel = payload.unsupportedLabel || DEFAULT_UNSUPPORTED_LABEL;
-  const preferredAgentLogin = env('AGENT_LOGIN', 'github-copilot[bot]').toLowerCase();
-  const knownAgentLogins = new Set(
-    parseCsv(env('AGENT_KNOWN_LOGINS', DEFAULT_KNOWN_AGENT_LOGINS)).map((login) => login.toLowerCase())
-  );
-  const items = [...(payload.candidateItems || []), ...(payload.staleActiveItems || [])];
-  const itemMap = new Map(items.map((item) => [item.issue.ref, item]));
-  const surfaced = [];
-
-  for (const attempt of payload.assignmentAttempts || []) {
-    if (!shouldSurfaceMissingActor(attempt)) continue;
-
-    const detail = itemMap.get(attempt.issue.ref);
-    if (!detail?.issue?.id) continue;
-
-    const [repoFullName, issueNumberText] = attempt.issue.ref.split('#');
-    const issueNumber = Number(issueNumberText);
-    if (!repoFullName || !issueNumber) continue;
-
-    const nextLabels = [
-      ...new Set([...(detail.labels || []).filter((label) => !ALL_AGENT_LABELS.includes(label)), unsupportedLabel]),
-    ];
-    const preservedHumanActorIds = retainedHumanActorIdsFromSerialized(detail, knownAgentLogins);
-    const technicalAgentLogins = technicalAgentLoginsFromSerialized(detail, knownAgentLogins);
-
-    await ensureLabelExists(repoFullName, unsupportedLabel);
-    await replaceIssueLabels(repoFullName, issueNumber, nextLabels);
-
-    let clearedAgentAssignee = false;
-    const cleanupWarnings = [];
-    try {
-      await replaceAssignableActors(detail.issue.id, preservedHumanActorIds);
-      clearedAgentAssignee = true;
-    } catch (error) {
-      cleanupWarnings.push(`Falha ao limpar assignee técnico automaticamente por GraphQL: ${error.message || error}`);
-    }
-
-    if (technicalAgentLogins.length > 0) {
-      try {
-        await removeIssueAssignees(repoFullName, issueNumber, technicalAgentLogins);
-        clearedAgentAssignee = true;
-      } catch (error) {
-        cleanupWarnings.push(`Falha ao limpar assignee técnico por REST: ${error.message || error}`);
-      }
-    }
-
-    if (cleanupWarnings.length > 0) {
-      attempt.cleanupWarning = cleanupWarnings.join(' | ');
-    }
-
-    await addIssueComment(
-      detail.issue.id,
-      buildUnavailableComment(payload.role, attempt.issue.ref, unsupportedLabel, preferredAgentLogin)
-    );
-
-    attempt.status = 'blocked';
-    attempt.reason = `Repositório sem actor atribuível do Copilot cloud agent; issue marcada com ${unsupportedLabel}.`;
-    attempt.cleanupClearedAgentAssignee = clearedAgentAssignee;
-    surfaced.push(attempt.issue.ref);
-  }
-
-  return surfaced;
-}
-
 async function main() {
   const role = env('AGENT_DISPATCH_ROLE');
   if (!role) throw new Error('AGENT_DISPATCH_ROLE is required');
@@ -285,14 +49,20 @@ async function main() {
   }
 
   const payload = JSON.parse(fs.readFileSync(outPath, 'utf8'));
-  const surfaced = await surfaceMissingActorBlocks(payload);
-  if (surfaced.length > 0) {
-    payload.ok = true;
-    payload.surfacedMissingActorBlocks = surfaced;
-    payload.reason = `Tasks elegíveis encontradas sem actor atribuível do Copilot; bloqueios registrados em ${surfaced.join(', ')}.`;
-    fs.writeFileSync(outPath, JSON.stringify(payload, null, 2));
-    console.log(JSON.stringify({ ok: true, role, surfacedMissingActorBlocks: surfaced, outPath }, null, 2));
-  }
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        role,
+        discoveryMode: payload.discoveryMode || 'labels-and-columns-only',
+        selectedIssue: payload.selectedItem?.issue?.ref || null,
+        candidateCount: payload.candidateCount || 0,
+        outPath,
+      },
+      null,
+      2
+    )
+  );
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- remove assignee-based routing and fallback semantics from the central agent flow
- switch the dispatcher and flow sync logic to discover work by labels and board columns only
- make `open` and `closed` irrelevant to agent routing, and reserve issue closing to humans only
- document the new sysadmin escalation rule for infrastructure blockers and the new column ownership rules

## What changed
- updated the central `AGENTS.md` and shared governance docs to forbid assignee-based capture in every case
- documented that agents do not close tasks; for agents, completion means advancing the card to the next column or tag, while `closed` remains human-only
- rewrote the dispatcher path to select tasks by tag and column only, without assigning actors, without posting assignment comments, and without gating on `open` or `closed`
- updated the flow sync logic to seed `agent:developer`, route merge-conflict items to `agent:devops`, and remove lingering assignees from `Work`/`Working` and `Deploy`
- documented that `Developer`, `Security`, `Quality Assurance`, and `Sysadmin` read `Work`/`Working`, `DevOps` reads `Deploy`, and document-oriented agents such as `Documentor` read `Done`
- documented that any agent blocked by infrastructure must open or update a separate `agent:sysadmin` issue in `Work`

## Validation
- confirmed the branch is ahead of `master` with only the expected structural changes in `agents-mcp`
- checked the updated dispatcher and flow sync files to ensure they no longer use `issue.state === OPEN` as a work-selection gate
- checked live open issues in `ControleOnline/agents-mcp`, `ControleOnline/app-community#41`, and `ControleOnline/api-community#5`; no active assignees were present in those sampled items at the time of this change
- could not perform a guaranteed board-wide assignee sweep from this session because the available GitHub connector surface does not expose a direct ProjectV2-wide assignee cleanup mutation here

Refs #92