### PR TITLE
hotfix: align CTO supervisor with agents-mcp runtime

### DIFF
--- a/automate/agents/runner-map.md
+++ b/automate/agents/runner-map.md
@@ -1,14 +1,22 @@
 # Runner Map
 
-Este arquivo existe para eliminar ambiguidade entre os workflows ativos do `cto-mcp` e as entradas legadas de compatibilidade que ainda permanecem no repositório.
+Este arquivo existe para eliminar ambiguidade entre o runtime atual do `agents-mcp`, os workflows desativados do GitHub Actions e as entradas legadas que ainda permanecem no repositório.
 
-## Cadeia ativa dos runners
+## Cadeia oficial atual
 
-Quando a pergunta for "o que realmente roda hoje no GitHub Actions?", a resposta correta deve seguir primeiro os workflows em `.github/workflows/`, depois os arquivos de `src/` e só então as entradas de `automate/`.
+Hoje a execução operacional oficial pertence aos agentes pares no ChatGPT.
+
+Com isso:
+
+- os workflows em `.github/workflows/` permanecem apenas como trilha histórica e ponto explícito de desligamento do canal antigo;
+- os entry points em `src/` e os scripts em `automate/` continuam sendo a referência real de comportamento;
+- a ausência de `schedule` ou `push` nos workflows desativados não desautoriza o runner correspondente.
+
+## Referências por papel
 
 ### Developer
 
-- Workflow ativo: `.github/workflows/developer-runner.yml`
+- Workflow desativado: `.github/workflows/developer-runner.yml`
 - Entry point de runtime: `src/developer-runner.js`
 - Runner comum: `src/agent-dispatch-runner.js`
 - Wrapper do papel: `automate/agents/developer/dispatch.mjs`
@@ -16,7 +24,7 @@ Quando a pergunta for "o que realmente roda hoje no GitHub Actions?", a resposta
 
 ### Quality Assurance
 
-- Workflow ativo: `.github/workflows/qa-runner.yml`
+- Workflow desativado: `.github/workflows/qa-runner.yml`
 - Entry point de runtime: `src/qa-runner.js`
 - Runner comum: `src/agent-dispatch-runner.js`
 - Wrapper do papel: `automate/agents/qa/dispatch.mjs`
@@ -24,7 +32,7 @@ Quando a pergunta for "o que realmente roda hoje no GitHub Actions?", a resposta
 
 ### Security
 
-- Workflow ativo: `.github/workflows/security-runner.yml`
+- Workflow desativado: `.github/workflows/security-runner.yml`
 - Entry point de runtime: `src/security-runner.js`
 - Runner comum: `src/agent-dispatch-runner.js`
 - Wrapper do papel: `automate/agents/security/dispatch.mjs`
@@ -32,44 +40,54 @@ Quando a pergunta for "o que realmente roda hoje no GitHub Actions?", a resposta
 
 ### DevOps
 
-- Workflow ativo: `.github/workflows/devops-runner.yml`
+- Workflow desativado: `.github/workflows/devops-runner.yml`
 - Entry point de runtime: `src/devops-runner.js`
 - Runner comum: `src/agent-dispatch-runner.js`
 - Papel resolvido pela variável `AGENT_DISPATCH_ROLE=devops`
 - Lógica compartilhada final: `automate/scripts/agent-project-dispatch.mjs`
 
+### Agent Flow Sync
+
+- Workflow desativado: `.github/workflows/agent-flow-sync.yml`
+- Entry point de runtime: `src/agent-flow-sync-runner.js`
+- Lógica final: `automate/scripts/agent-flow-sync.mjs`
+
 ### CTO
 
-- Workflow ativo: `.github/workflows/cto-runner.yml`
+- Workflow desativado: `.github/workflows/cto-runner.yml`
 - Entry point de runtime: `src/cto-runner.js`
 - Lógica final: `automate/scripts/cto-project-supervisor.mjs`
 
 ## Entradas legadas ou de compatibilidade
 
-Os arquivos abaixo continuam úteis como referência histórica, compatibilidade manual ou trilha de política, mas não representam o caminho principal dos runners recorrentes atuais:
+Os arquivos abaixo continuam úteis como referência histórica, compatibilidade manual ou trilha de política, mas não representam o canal operacional principal atual:
 
 - `src/index.js`
 - `automate/scripts/qa-project-review.mjs`
 - `automate/scripts/security-project-review.mjs`
 
-Se houver divergência entre esses arquivos legados e os workflows ativos, a leitura operacional correta deve priorizar os workflows ativos e a cadeia real de `src/*-runner.js` até `automate/scripts/agent-project-dispatch.mjs`.
+Se houver divergência entre arquivos legados, workflows desativados e a trilha atual, a leitura operacional correta deve priorizar:
+
+1. a política canônica em `skills/runners/README.md`;
+2. os entry points reais em `src/*-runner.js`;
+3. os wrappers em `automate/agents/`, quando existirem;
+4. a lógica final em `automate/scripts/`.
 
 ## Regra de auditoria
 
 Ao revisar funcionamento, incidentes, ownership ou backlog do ecossistema:
 
-1. confirme primeiro qual workflow ativo dispara o papel;
-2. confirme qual entry point de `src/` esse workflow executa hoje;
-3. confirme se o papel cai no dispatcher comum ou num script dedicado;
-4. só trate script legado como fonte principal quando ele ainda estiver no caminho real do workflow;
-5. quando a issue estiver em `override manual ativo`, preserve essa leitura até surgir delta técnico verificável no repositório alvo; não trate a simples remoção do owner humano como progresso nem como prova de fila limpa;
-6. quando houver PR com `Scrutinizer` em erro/failure, sem `workflow_run` local observável ou com run em `action_required`, leia isso primeiro como gate repo-local do repositório alvo antes de reciclar a issue entre agents.
+1. confirme primeiro qual runner e script realmente implementam o papel hoje;
+2. trate `workflow_dispatch` nos YAMLs desativados apenas como trilha histórica;
+3. só trate script legado como fonte principal quando ele ainda estiver no caminho real do runtime;
+4. quando a issue estiver em `override manual ativo`, preserve essa leitura até surgir delta técnico verificável no repositório alvo; não trate a simples remoção do owner humano como progresso nem como prova de fila limpa;
+5. quando houver PR com `Scrutinizer` em erro ou failure, sem `workflow_run` local observável ou com run em `action_required`, leia isso primeiro como gate repo-local do repositório alvo antes de reciclar a issue entre agents.
 
 ## Regra de interpretação de gargalo
 
-Quando o bloqueio dominante estiver fora do núcleo `cto-mcp`, a sequência correta de leitura é:
+Quando o bloqueio dominante estiver fora do núcleo `agents-mcp`, a sequência correta de leitura é:
 
-1. verificar se existe PR/composição aberta no próprio repositório consumidor;
+1. verificar se existe PR ou composição aberta no próprio repositório consumidor;
 2. verificar se o head atual publica check externo em erro ou failure;
 3. verificar se existe `workflow_run` local observável para o mesmo head;
 4. se não houver run local, ou se o run estiver em `action_required`, tratar a trilha como bloqueio repo-local material;

--- a/src/cto-runner.js
+++ b/src/cto-runner.js
@@ -1,5 +1,6 @@
 import { getAuthToken } from './github-app-auth.js';
 
 process.env.GITHUB_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || await getAuthToken();
+process.env.CTO_CORE_REPOSITORY = process.env.CTO_CORE_REPOSITORY || 'ControleOnline/agents-mcp';
 
 await import('../automate/scripts/cto-project-supervisor.mjs');


### PR DESCRIPTION
## Summary
- force the CTO runner to audit `ControleOnline/agents-mcp` as the core repository by default
- realign the internal runner map with the current peer-agent runtime model
- remove stale guidance that still described disabled GitHub workflows as the active execution path

## Why
The canonical CTO instructions and shared runner documentation already treat `ControleOnline/agents-mcp` as the source of truth, with operational execution happening through peer agents in ChatGPT. The local runtime still carried two stale signals:
- `src/cto-runner.js` did not override the legacy core repository default used by `cto-project-supervisor.mjs`
- `automate/agents/runner-map.md` still described `cto-mcp` and active GitHub workflows, contradicting the current operating model

That mismatch could make the supervisor audit the wrong core repository and could mislead future investigations about what actually runs today.

## Validation
- confirmed the canonical CTO source points to `ControleOnline/agents-mcp`
- confirmed `skills/runners/README.md` documents GitHub workflows as disabled and peer agents as the official execution channel
- confirmed the hotfix branch is `ahead_by=2` and `behind_by=0` against `master`
- re-read the changed files from the published hotfix branch to verify the runtime override and updated runner map

## Follow-through
This hotfix does not close the ecosystem supervisory issue by itself. Priority-repo residuals still exist in:
- `ControleOnline/app-community#74` with PR `#146` and `Scrutinizer = failure`
- `ControleOnline/api-community#23` with PR `#25` and `Scrutinizer = error`
- `ControleOnline/app-community#143` with PR `#144` and `Scrutinizer = error`
