### PR TITLE
hotfix: reconcile CTO runtime, runner map and GitHub manager model

### DIFF
--- a/automate/agents/runner-map.md
+++ b/automate/agents/runner-map.md
@@ -1,10 +1,59 @@
 # Runner Map
 
-Este arquivo existe para eliminar ambiguidade entre a documentacao historica e o que realmente roda hoje no GitHub Actions.
+Este arquivo existe para eliminar ambiguidade entre o runtime atual do `agents-mcp`, o runner gerencial de mutacoes no GitHub e os workflows historicos que ainda permanecem no repositorio.
 
-## Cadeia ativa dos runners
+## Cadeia oficial atual
 
-Quando a pergunta for "o que realmente roda hoje no GitHub Actions?", a resposta correta passa a ser:
+Hoje a execucao operacional oficial do ecossistema combina duas trilhas complementares:
+
+- os agents pares no ChatGPT executam a trilha normal por papel, incluindo descoberta, implementacao, revisao tecnica e handoff;
+- o `GitHub Manager Runner` executa a trilha oficial de mutacoes remotas no GitHub e de manutencao recorrente dentro do proprio GitHub.
+
+Com isso:
+
+- os workflows em `.github/workflows/` por papel permanecem como trilha historica e ponto explicito de desligamento do canal antigo;
+- os entry points em `src/` e os scripts em `automate/` continuam sendo a referencia real de comportamento por papel;
+- o workflow `.github/workflows/github-operations.yml` continua sendo o canal oficial quando a etapa depender de coluna, label, comentario, review, assignee ou outra escrita remota no GitHub.
+
+## Referencias por papel
+
+### Developer
+
+- workflow desativado: `.github/workflows/developer-runner.yml`
+- entry point de runtime: `src/developer-runner.js`
+- runner comum: `src/agent-dispatch-runner.js`
+- wrapper do papel: `automate/agents/developer/dispatch.mjs`
+- logica compartilhada final: `automate/scripts/agent-project-dispatch.mjs`
+
+### Quality Assurance
+
+- workflow desativado: `.github/workflows/qa-runner.yml`
+- entry point de runtime: `src/qa-runner.js`
+- runner comum: `src/agent-dispatch-runner.js`
+- wrapper do papel: `automate/agents/qa/dispatch.mjs`
+- logica compartilhada final: `automate/scripts/agent-project-dispatch.mjs`
+
+### Security
+
+- workflow desativado: `.github/workflows/security-runner.yml`
+- entry point de runtime: `src/security-runner.js`
+- runner comum: `src/agent-dispatch-runner.js`
+- wrapper do papel: `automate/agents/security/dispatch.mjs`
+- logica compartilhada final: `automate/scripts/agent-project-dispatch.mjs`
+
+### DevOps
+
+- workflow desativado: `.github/workflows/devops-runner.yml`
+- entry point de runtime: `src/devops-runner.js`
+- runner comum: `src/agent-dispatch-runner.js`
+- papel resolvido pela variavel `AGENT_DISPATCH_ROLE=devops`
+- logica compartilhada final: `automate/scripts/agent-project-dispatch.mjs`
+
+### CTO
+
+- workflow desativado: `.github/workflows/cto-runner.yml`
+- entry point de runtime: `src/cto-runner.js`
+- logica final: `automate/scripts/cto-project-supervisor.mjs`
 
 ### GitHub Manager
 
@@ -14,15 +63,37 @@ Quando a pergunta for "o que realmente roda hoje no GitHub Actions?", a resposta
 
 ## Entradas legadas ou de compatibilidade
 
-Os workflows por papel, sincronizadores e supervisores antigos deixam de representar a cadeia principal de execucao recorrente.
+Os arquivos abaixo continuam uteis como referencia historica, compatibilidade manual ou trilha de politica, mas nao representam a trilha principal de execucao recorrente:
 
-Se ainda existirem scripts legados no repositorio, eles devem ser lidos apenas como referencia historica ate consolidacao total no runner gerencial.
+- `src/index.js`
+- `automate/scripts/qa-project-review.mjs`
+- `automate/scripts/security-project-review.mjs`
+
+Se houver divergencia entre arquivos legados, workflows desativados e a trilha atual, a leitura operacional correta deve priorizar:
+
+1. `skills/runners/README.md`
+2. `skills/shared/README.md`
+3. os entry points reais em `src/*-runner.js`
+4. os wrappers em `automate/agents/`, quando existirem
+5. a logica final em `automate/scripts/`
+6. o `GitHub Manager Runner` quando a etapa depender de mutacao remota no GitHub
 
 ## Regra de auditoria
 
 Ao revisar funcionamento, incidentes, ownership ou backlog do ecossistema:
 
-1. confirme primeiro o workflow `.github/workflows/github-operations.yml`
-2. confirme a logica em `automate/scripts/github-operations.mjs`
-3. confirme o estado atual no ProjectV2 e nas issues/PRs do GitHub
-4. trate qualquer outro runner antigo como legado, salvo se houver reativacao explicita e documentada
+1. confirme primeiro qual runner e script realmente implementam o papel ou a mutacao exigida hoje
+2. trate `workflow_dispatch` nos YAMLs por papel apenas como trilha historica, salvo reativacao explicita e documentada
+3. so trate script legado como fonte principal quando ele ainda estiver no caminho real do runtime
+4. quando a issue estiver em `override manual ativo`, preserve essa leitura ate surgir delta tecnico verificavel no repositorio alvo
+5. quando houver PR com `Scrutinizer` em erro ou failure, sem `workflow_run` local observavel ou com run em `action_required`, leia isso primeiro como gate repo-local do repositorio alvo antes de reciclar a issue entre agents
+
+## Regra de interpretacao de gargalo
+
+Quando o bloqueio dominante estiver fora do nucleo `agents-mcp`, a sequencia correta de leitura e:
+
+1. verificar se existe PR ou composicao aberta no proprio repositorio consumidor
+2. verificar se o head atual publica check externo em erro ou failure
+3. verificar se existe `workflow_run` local observavel para o mesmo head
+4. se nao houver run local, ou se o run estiver em `action_required`, tratar a trilha como bloqueio repo-local material
+5. so depois disso decidir se o problema e do nucleo, do repositorio consumidor ou apenas do gate externo

--- a/skills/runners/README.md
+++ b/skills/runners/README.md
@@ -1,19 +1,19 @@
 # Runner Skills
 
-Este arquivo passa a mapear um unico runner oficial para execucao remota no GitHub.
+Este arquivo mapeia o modelo atual de execucao do ecossistema sem misturar o papel dos agents pares no ChatGPT com o papel do runner gerencial no GitHub.
 
 ## Estado atual
 
-O workflow oficial do ecossistema agora e:
+Hoje existem duas trilhas oficiais e complementares:
 
-- `.github/workflows/github-operations.yml`
+- os agents pares no ChatGPT sao o canal oficial para execucao normal por papel, investigacao, correcao de codigo, revisao tecnica e handoff operacional;
+- o workflow `.github/workflows/github-operations.yml` e o canal oficial para mutacoes remotas no GitHub e manutencao recorrente dentro do proprio GitHub.
 
 Com isso:
 
-- a automacao recorrente de coluna, labels e manutencao do ProjectV2 acontece em um unico runner gerencial
-- comandos remotos de mutacao no GitHub tambem passam pelo mesmo runner
-- os demais workflows antigos deixam de ser a trilha oficial
-- a logica real fica em `automate/scripts/github-operations.mjs`
+- `Developer`, `Security`, `Quality Assurance`, `DevOps` e `CTO` continuam tendo comportamento real definido pelos entry points em `src/`, wrappers em `automate/agents/` e scripts em `automate/scripts/`;
+- o `GitHub Manager Runner` concentra auditoria gerencial, correcoes de coluna, labels, assignees, comentarios, reviews e outras mutacoes remotas quando a sessao local nao deve fingir escrita no GitHub;
+- os workflows antigos por papel deixam de ser a trilha oficial de execucao recorrente, mas continuam como referencia historica e ponto explicito de desligamento do canal anterior.
 
 ## GitHub Manager Runner
 
@@ -30,6 +30,21 @@ Responsabilidades de referencia:
 - executar mutacoes REST ou GraphQL autorizadas por comando
 - servir como runner com mais acesso para manutencao geral no GitHub
 
+## Runners por papel
+
+Os entry points de papel continuam sendo a referencia de comportamento do ecossistema:
+
+- `src/developer-runner.js`
+- `src/security-runner.js`
+- `src/qa-runner.js`
+- `src/devops-runner.js`
+- `src/cto-runner.js`
+- `src/agent-dispatch-runner.js`
+- `automate/scripts/agent-project-dispatch.mjs`
+- `automate/scripts/cto-project-supervisor.mjs`
+
+Quando a duvida envolver ownership, fila, selecao por labels/coluna ou leitura operacional do papel, use esses entry points e scripts junto com `skills/shared/README.md` e `automate/agents/runner-map.md`.
+
 ## Legado
 
-Os workflows por papel e os sincronizadores antigos deixam de ser runners oficiais. Quando ainda existirem scripts ou wrappers historicos no repositorio, trate-os apenas como referencia legada ate serem removidos ou absorvidos pelo runner gerencial.
+Os workflows por papel e os sincronizadores antigos nao sao mais a trilha oficial de execucao recorrente. Quando ainda existirem wrappers ou scripts historicos no repositorio, trate-os como referencia legada ate remocao ou consolidacao completa no modelo atual.

--- a/src/cto-runner.js
+++ b/src/cto-runner.js
@@ -1,5 +1,6 @@
 import { getAuthToken } from './github-app-auth.js';
 
 process.env.GITHUB_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || await getAuthToken();
+process.env.CTO_CORE_REPOSITORY = process.env.CTO_CORE_REPOSITORY || 'ControleOnline/agents-mcp';
 
 await import('../automate/scripts/cto-project-supervisor.mjs');


### PR DESCRIPTION
## Summary
- align the CTO runtime entrypoint with `ControleOnline/agents-mcp` as the core repository
- reconcile the runner documentation with the real split between peer-agent execution and the GitHub Manager mutation channel
- replace the stale single-runner narrative that no longer matched the shared governance docs

## Why
The canonical CTO and shared docs already treat `ControleOnline/agents-mcp` as the central source of truth, but the runtime and runner docs were still sending mixed signals:
- `src/cto-runner.js` still inherited the old default core repository unless an override was injected
- `skills/runners/README.md` described a single official runner, which conflicted with the current peer-agent operating model
- `automate/agents/runner-map.md` still collapsed everything into the GitHub Manager path, hiding the real role entrypoints used by the ecosystem

That combination could misdirect supervision, confuse future audits and make the wrong runtime look canonical.

## Change
- set `CTO_CORE_REPOSITORY` to `ControleOnline/agents-mcp` in `src/cto-runner.js`
- rewrite `skills/runners/README.md` so it distinguishes peer-agent execution from the GitHub Manager mutation channel
- rewrite `automate/agents/runner-map.md` so it maps the real role entrypoints, the active GitHub Manager workflow and the legacy workflows separately

## Validation
- confirmed the canonical CTO source points to `ControleOnline/agents-mcp`
- confirmed `skills/shared/README.md` already treats the GitHub Manager Runner as the preferred mutation channel, not the only execution channel
- confirmed the new branch is ahead of current `master` and not behind it
- re-read the changed files after publication to verify the runtime default and the documentation alignment

## Follow-through
This hotfix restores a coherent source of truth in the core repository. Priority-repo residuals still need separate operational follow-up in:
- `ControleOnline/app-community#143` with PR `#148`
- `ControleOnline/api-community#23` with PR `#25`
- `ControleOnline/agents-mcp#92`
